### PR TITLE
Removed Serializer by restructuring. Big refactor.

### DIFF
--- a/JSONCore Performance Tests/JSONCorePerformanceTests.swift
+++ b/JSONCore Performance Tests/JSONCorePerformanceTests.swift
@@ -28,7 +28,7 @@ class JSONCorePerformanceTests: XCTestCase {
         let json = String.fromCString(unsafeBitCast(data.bytes, UnsafePointer<CChar>.self))!
         measureBlock {
             do {
-                let value = try JSONParser.parseData(json.unicodeScalars)
+                let value = try JSONParser.parse(json.unicodeScalars)
                 let coordinates = value.object!["coordinates"]!.array!
                 let len = coordinates.count
                 var x = 0.0; var y = 0.0; var z = 0.0

--- a/JSONCoreDemo/JSONCoreDemo.xcodeproj/xcshareddata/xcschemes/JSONCoreDemo.xcscheme
+++ b/JSONCoreDemo/JSONCoreDemo.xcodeproj/xcshareddata/xcschemes/JSONCoreDemo.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8B2999C91C0F228A003D6E8A"
+               BuildableName = "JSONCoreDemo.app"
+               BlueprintName = "JSONCoreDemo"
+               ReferencedContainer = "container:JSONCoreDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B2999C91C0F228A003D6E8A"
+            BuildableName = "JSONCoreDemo.app"
+            BlueprintName = "JSONCoreDemo"
+            ReferencedContainer = "container:JSONCoreDemo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B2999C91C0F228A003D6E8A"
+            BuildableName = "JSONCoreDemo.app"
+            BlueprintName = "JSONCoreDemo"
+            ReferencedContainer = "container:JSONCoreDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B2999C91C0F228A003D6E8A"
+            BuildableName = "JSONCoreDemo.app"
+            BlueprintName = "JSONCoreDemo"
+            ReferencedContainer = "container:JSONCoreDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/JSONCoreTests/JSONCoreTests.swift
+++ b/JSONCoreTests/JSONCoreTests.swift
@@ -10,6 +10,26 @@ import XCTest
 import JSONCore
 import Foundation
 
+extension JSONParseError: Equatable {
+}
+public func == (lhs: JSONParseError, rhs: JSONParseError) -> Bool {
+    switch (lhs, rhs) {
+    case (.Unknown, .Unknown): return true
+    case (.EmptyInput, .EmptyInput): return true
+    case (.UnterminatedString, .UnterminatedString): return true
+    case (.InvalidUnicode, .InvalidUnicode): return true
+    case (.EndOfFile, .EndOfFile): return true
+    case let (.UnexpectedCharacter(lineLHS, charLHS), .UnexpectedCharacter(lineRHS, charRHS)):
+        return lineLHS == lineRHS && charLHS == charRHS
+    case let (.UnexpectedKeyword(lineLHS, charLHS), .UnexpectedKeyword(lineRHS, charRHS)):
+        return lineLHS == lineRHS && charLHS == charRHS
+    case let (.InvalidNumber(lineLHS, charLHS), .InvalidNumber(lineRHS, charRHS)):
+        return lineLHS == lineRHS && charLHS == charRHS
+    default: return false
+        
+    }
+}
+
 class JSONCoreTests: XCTestCase {
     
     override func setUp() {
@@ -22,18 +42,18 @@ class JSONCoreTests: XCTestCase {
         super.tearDown()
     }
     
-    func expectError(error: JSONParseError, json: String, file: String = __FILE__, line: UInt = __LINE__) {
+    func expectError(error: JSONParseError, json: String, file: StaticString = #file, line: UInt = #line) {
         do {
-            try JSONParser.parseData(json.unicodeScalars)
+            try JSONParser.parse(json.unicodeScalars)
             XCTFail("Expected error, got success", file: file, line: line)
         } catch let err {
             XCTAssertEqual((err as! JSONParseError), error, file: file, line: line)
         }
     }
     
-    func expectErrorString(error: String, json: String, file: String = __FILE__, line: UInt = __LINE__) {
+    func expectErrorString(error: String, json: String, file: StaticString = #file, line: UInt = #line) {
         do {
-            try JSONParser.parseData(json.unicodeScalars)
+            try JSONParser.parse(json.unicodeScalars)
             XCTFail("Expected error, got success", file: file, line: line)
         } catch let err {
             if let printableError = err as? CustomStringConvertible {
@@ -43,9 +63,9 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectValue(value: JSONValue, json: String, file: String = __FILE__, line: UInt = __LINE__) {
+    func expectValue(value: JSON, json: String, file: StaticString = #file, line: UInt = #line) {
         do {
-            let parsedValue = try JSONParser.parseData(json.unicodeScalars)
+            let parsedValue = try JSONParser.parse(json.unicodeScalars)
             XCTAssertEqual(value, parsedValue, file: file, line: line)
         } catch let err {
             if let printableError = err as? CustomStringConvertible {
@@ -54,9 +74,9 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectString(string: String, json: JSONValue, file: String = __FILE__, line: UInt = __LINE__) {
+    func expectString(string: String, json: JSON, file: StaticString = #file, line: UInt = #line) {
         do {
-            let serialized = try JSONSerializer.serializeValue(json, prettyPrint: false)
+            let serialized = try json.jsonString()
             XCTAssertEqual(string, serialized, file: file, line: line)
         } catch let err {
             if let printableError = err as? CustomStringConvertible {
@@ -68,7 +88,7 @@ class JSONCoreTests: XCTestCase {
     func testSanity() {
         let json = "{\"function\":null,\"numbers\":[4,8,15,16,23,42],\"y_index\":2,\"x_index\":12,\"z_index\":5,\"arcs\":[{\"p2\":[22.1,50],\"p1\":[10.5,15.5],\"radius\":5},{\"p2\":[23.1,40],\"p1\":[11.5,15.5],\"radius\":10},{\"p2\":[23.1,30],\"p1\":[12.5,15.5],\"radius\":3},{\"p2\":[24.1,20],\"p1\":[13.5,15.5],\"radius\":2},{\"p2\":[25.1,10],\"p1\":[14.5,15.5],\"radius\":8},{\"p2\":[26.1,0],\"p1\":[15.5,15.5],\"radius\":2}],\"label\":\"my label\"}"
         do {
-            try JSONParser.parseData(json.unicodeScalars)
+            try JSONParser.parse(json.unicodeScalars)
         } catch let err {
             if let printableError = err as? CustomStringConvertible {
                 XCTFail("JSON parse error: \(printableError)")
@@ -82,8 +102,8 @@ class JSONCoreTests: XCTestCase {
     }
     
     func testParseBool() {
-        expectValue(.JSONBool(true), json: "true")
-        expectValue(.JSONBool(false), json: "false")
+        expectValue(.bool(true), json: "true")
+        expectValue(.bool(false), json: "false")
         expectError(.UnexpectedCharacter(lineNumber: 0, characterNumber: 5), json: "truex")
         expectError(.UnexpectedCharacter(lineNumber: 0, characterNumber: 6), json: "falsex")
         expectError(.UnexpectedKeyword(lineNumber: 0, characterNumber: 1), json: "tru")
@@ -91,102 +111,141 @@ class JSONCoreTests: XCTestCase {
     }
     
     func testParseNumbers() {
-        expectValue(.JSONNumber(.JSONIntegral(0)), json: "0")
-        expectValue(.JSONNumber(.JSONIntegral(9223372036854775807)), json: "9223372036854775807")
-        expectValue(.JSONNumber(.JSONIntegral(-9223372036854775808)), json: "-9223372036854775808")
-        expectValue(.JSONNumber(.JSONFractional(1.0)), json: "10e-1")
-        expectValue(.JSONNumber(.JSONFractional(0.1)), json: "0.1")
+        expectValue(.integer(0), json: "0")
+        expectValue(.integer(9223372036854775807), json: "9223372036854775807")
+        expectValue(.integer(-9223372036854775808), json: "-9223372036854775808")
+        expectValue(.double(1.0), json: "10e-1")
+        expectValue(.double(0.1), json: "0.1")
         // Floating point numbers are the actual worst
-        expectValue(.JSONNumber(.JSONFractional(0.000000050000000000000011)), json: "5e-8")
-        expectValue(.JSONNumber(.JSONFractional(0.1)), json: "0.1")
-        expectValue(.JSONNumber(.JSONFractional(0.52)), json: "5.2e-1")
+        expectValue(.double(0.000000050000000000000011), json: "5e-8")
+        expectValue(.double(0.1), json: "0.1")
+        expectValue(.double(0.52), json: "5.2e-1")
     }
     
     func testParseUnicode() {
-        expectValue(.JSONString("и"), json: "\"\\u0438\"")
-        expectValue(.JSONString("𝄞"), json: "\"\\ud834\\udd1e\"")
+        expectValue(.string("и"), json: "\"\\u0438\"")
+        expectValue(.string("𝄞"), json: "\"\\ud834\\udd1e\"")
     }
     
     func testSerializeBool() {
-        expectString("true", json: JSONValue.JSONBool(true))
-        expectString("false", json: JSONValue.JSONBool(false))
+        expectString("true", json: JSON.bool(true))
+        expectString("false", json: JSON.bool(false))
     }
     
     func testSerializeNumber() {
-        expectString("0", json: JSONValue.JSONNumber(.JSONIntegral(0)))
-        expectString("9223372036854775807", json: JSONValue.JSONNumber(.JSONIntegral(9223372036854775807)))
-        expectString("-9223372036854775808", json: JSONValue.JSONNumber(.JSONIntegral(-9223372036854775808)))
-        expectString("0.1", json: JSONValue.JSONNumber(.JSONFractional(0.1)))
-        expectString("10.01", json: JSONValue.JSONNumber(.JSONFractional(10.01)))
+        expectString("0", json: JSON.integer(0))
+        expectString("9223372036854775807", json: JSON.integer(9223372036854775807))
+        expectString("-9223372036854775808", json: JSON.integer(-9223372036854775808))
+        expectString("0.1", json: JSON.double(0.1))
+        expectString("10.01", json: JSON.double(10.01))
     }
     
     func testSerializeNull() {
-        expectString("null", json: JSONValue.JSONNull)
+        expectString("null", json: JSON.null)
     }
     
     func testSerializeString() {
-        expectString("\"test\"", json: JSONValue.JSONString("test"))
-        expectString("\"test 1, test 2\"", json: JSONValue.JSONString("test 1, test 2"))
-        expectString("\"Привет\"", json: JSONValue.JSONString("Привет"))
-        expectString("\"𝄞\"", json: JSONValue.JSONString("𝄞"))
+        expectString("\"test\"", json: JSON.string("test"))
+        expectString("\"test 1, test 2\"", json: JSON.string("test 1, test 2"))
+        expectString("\"Привет\"", json: JSON.string("Привет"))
+        expectString("\"𝄞\"", json: JSON.string("𝄞"))
     }
     
     func testSerializeStringEscapes() {
-        expectString("\"\\r\\n\\t\\\\/\"", json: JSONValue.JSONString("\r\n\t\\/"))
+        expectString("\"\\r\\n\\t\\\\/\"", json: JSON.string("\r\n\t\\/"))
         let backspace = UnicodeScalar(0x0008)
         var backspaceStr = ""
         backspaceStr.append(backspace)
-        expectString("\"\\b\"", json: JSONValue.JSONString(backspaceStr))
+        expectString("\"\\b\"", json: JSON.string(backspaceStr))
     }
     
     func testSerializeUnicodeEscapes() {
-        expectString("\"\\u001f\"", json: "\u{001F}" as JSONValue)
-        expectString("\"\\u0000\"", json: "\u{0000}" as JSONValue)
-        expectString("\"\\u001c\"", json: "\u{001C}" as JSONValue)
+        expectString("\"\\u001f\"", json: "\u{001F}" as JSON)
+        expectString("\"\\u0000\"", json: "\u{0000}" as JSON)
+        expectString("\"\\u001c\"", json: "\u{001C}" as JSON)
         
     }
     
     func testSerializeArray() {
-        let arr: JSONValue = [
+        let arr: JSON = [
             1, 2.1, true, false, "x", nil
         ]
-        let nestedArr: JSONValue = [arr]
+        let nestedArr: JSON = [arr]
         expectString("[1,2.1,true,false,\"x\",null]", json: arr)
         expectString("[[1,2.1,true,false,\"x\",null]]", json: nestedArr)
     }
     
     func testSerializeObject() {
-        let obj: JSONValue = [
+        let obj: JSON = [
             "integral": 1,
-            "fractional": 2.1,
+            "doubleal": 2.1,
             "true": true,
             "false": false,
             "str": "x",
             "null": nil
         ]
-        let str = try! JSONSerializer.serializeValue(obj, prettyPrint: false)
-        let returnedObj = try! JSONParser.parseData(str.unicodeScalars)
+        let str = try! obj.jsonString()
+        let returnedObj = try! JSONParser.parse(str.unicodeScalars)
         XCTAssertEqual(returnedObj, obj)
     }
     
     func testPrettyPrintNestedArray() {
-        let arr: JSONValue = [
+        let arr: JSON = [
             [1, 2, 3],
             [4, 5, 6]
         ]
         let expected = "[\n  [\n    1,\n    2,\n    3\n  ],\n  [\n    4,\n    5,\n    6\n  ]\n]"
-        let str = try! JSONSerializer.serializeValue(arr, prettyPrint: true)
+        let str = try! arr.jsonString()
         XCTAssertEqual(str, expected)
     }
     
     func testPrettyPrintNestedObjects() {
-        let obj: JSONValue = [
+        let obj: JSON = [
             "test": [
                 "1": 2
             ]
         ]
         let expected = "{\n  \"test\": {\n    \"1\": 2\n  }\n}"
-        let str = try! JSONSerializer.serializeValue(obj, prettyPrint: true)
+        let str = try! obj.jsonString()
         XCTAssertEqual(str, expected)
+    }
+    
+    func testOptionalSubscripting() {
+        var json: JSON = [
+            "name": "Ethan",
+            "yob": 1995,
+            "computer": [
+                "purchased": 2013,
+                "ports": [
+                    "usb1",
+                    "usb2",
+                    "thunderbolt1",
+                    "thunderbolt2"
+                ],
+                "memory": [
+                    "capacity": 8,
+                    "clock": 1.6,
+                    "type": "DDR3"
+                ]
+            ]
+        ]
+        
+        let jsonString = try! json.jsonString()
+        
+        let json2 = try! JSONParser.parse(jsonString)
+        
+        XCTAssertEqual(json, json2)
+        
+        XCTAssertEqual(json["yob"]?.int!, 1995)
+        XCTAssertEqual(json["computer"]["purchased"]?.int!, 2013)
+        XCTAssertEqual(json["computer"]["memory"]["type"]?.string!, "DDR3")
+        XCTAssertEqual(json["computer"]["ports"][1]?.string!, "usb2")
+    }
+    
+    func testSubscriptSetter() {
+        var json: JSON = ["height": 1.90]
+        XCTAssertEqual(json["height"]?.double!, 1.90)
+        json["height"] = 1.91
+        XCTAssertEqual(json["height"]?.double!, 1.91)
     }
 }

--- a/JSONCoreTests/JSONCoreTests.swift
+++ b/JSONCoreTests/JSONCoreTests.swift
@@ -42,7 +42,7 @@ class JSONCoreTests: XCTestCase {
         super.tearDown()
     }
     
-    func expectError(error: JSONParseError, json: String, file: StaticString = #file, line: UInt = #line) {
+    func expectError(error: JSONParseError, json: String, file: StaticString = __FILE__, line: UInt = __LINE__) {
         do {
             try JSONParser.parse(json.unicodeScalars)
             XCTFail("Expected error, got success", file: file, line: line)
@@ -51,7 +51,7 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectErrorString(error: String, json: String, file: StaticString = #file, line: UInt = #line) {
+    func expectErrorString(error: String, json: String, file: StaticString = __FILE__, line: UInt = __LINE__) {
         do {
             try JSONParser.parse(json.unicodeScalars)
             XCTFail("Expected error, got success", file: file, line: line)
@@ -63,7 +63,7 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectValue(value: JSON, json: String, file: StaticString = #file, line: UInt = #line) {
+    func expectValue(value: JSON, json: String, file: StaticString = __FILE__, line: UInt = __LINE__) {
         do {
             let parsedValue = try JSONParser.parse(json.unicodeScalars)
             XCTAssertEqual(value, parsedValue, file: file, line: line)
@@ -74,7 +74,7 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectString(string: String, json: JSON, file: StaticString = #file, line: UInt = #line) {
+    func expectString(string: String, json: JSON, file: StaticString = __FILE__, line: UInt = __LINE__) {
         do {
             let serialized = try json.jsonString()
             XCTAssertEqual(string, serialized, file: file, line: line)
@@ -210,7 +210,7 @@ class JSONCoreTests: XCTestCase {
         XCTAssertEqual(str, expected)
     }
     
-    func testOptionalSubscripting() {
+    func testSubscriptGetter() {
         var json: JSON = [
             "name": "Ethan",
             "yob": 1995,
@@ -236,16 +236,23 @@ class JSONCoreTests: XCTestCase {
         
         XCTAssertEqual(json, json2)
         
-        XCTAssertEqual(json["yob"]?.int!, 1995)
-        XCTAssertEqual(json["computer"]["purchased"]?.int!, 2013)
-        XCTAssertEqual(json["computer"]["memory"]["type"]?.string!, "DDR3")
-        XCTAssertEqual(json["computer"]["ports"][1]?.string!, "usb2")
+        XCTAssertEqual(json["yob"].int, 1995)
+        XCTAssertEqual(json["computer"]["purchased"].int, 2013)
+        XCTAssertEqual(json["computer"]["memory"]["type"].string, "DDR3")
+        XCTAssertEqual(json["computer"]["memory"]["type"].string, "DDR3")
+        XCTAssertEqual(json["computer"]?["memory"]?["type"].string, "DDR3")
+        XCTAssertEqual(json["computer"]["ports"][1].string, "usb2")
+        XCTAssertEqual(json["computer"]["ports"][-1].string, nil)
     }
     
     func testSubscriptSetter() {
-        var json: JSON = ["height": 1.90]
-        XCTAssertEqual(json["height"]?.double!, 1.90)
+        var json: JSON = ["height": 1.90, "array": [1, 2, 3]]
+        XCTAssertEqual(json["height"].double, 1.90)
         json["height"] = 1.91
-        XCTAssertEqual(json["height"]?.double!, 1.91)
+        XCTAssertEqual(json["height"].double, 1.91)
+        
+        XCTAssertEqual(json["array"][0], 1)
+        json["array"][0] = 4
+        XCTAssertEqual(json["array"][0], 4)
     }
 }

--- a/JSONCoreTests/JSONCoreTests.swift
+++ b/JSONCoreTests/JSONCoreTests.swift
@@ -42,7 +42,7 @@ class JSONCoreTests: XCTestCase {
         super.tearDown()
     }
     
-    func expectError(error: JSONParseError, json: String, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    func expectError(error: JSONParseError, json: String, file: String = __FILE__, line: UInt = __LINE__) {
         do {
             try JSONParser.parse(json.unicodeScalars)
             XCTFail("Expected error, got success", file: file, line: line)
@@ -51,7 +51,7 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectErrorString(error: String, json: String, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    func expectErrorString(error: String, json: String, file: String = __FILE__, line: UInt = __LINE__) {
         do {
             try JSONParser.parse(json.unicodeScalars)
             XCTFail("Expected error, got success", file: file, line: line)
@@ -63,7 +63,7 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectValue(value: JSON, json: String, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    func expectValue(value: JSON, json: String, file: String = __FILE__, line: UInt = __LINE__) {
         do {
             let parsedValue = try JSONParser.parse(json.unicodeScalars)
             XCTAssertEqual(value, parsedValue, file: file, line: line)
@@ -74,7 +74,7 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectString(string: String, json: JSON, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    func expectString(string: String, json: JSON, file: String = __FILE__, line: UInt = __LINE__) {
         do {
             let serialized = try json.jsonString()
             XCTAssertEqual(string, serialized, file: file, line: line)

--- a/Source/JSONCore.swift
+++ b/Source/JSONCore.swift
@@ -13,313 +13,347 @@
 
 /// Errors raised while serializing to a JSON string
 public enum JSONSerializeError: ErrorType {
-	/// Some unknown error, usually indicates something not yet implemented.
-	case Unknown
-	/// A number not supported by the JSON spec was encounterd, like infinity or NaN.
-	case InvalidNumber
+    /// Some unknown error, usually indicates something not yet implemented.
+    case Unknown
+    /// A number not supported by the JSON spec was encounterd, like infinity or NaN.
+    case InvalidNumber
 }
 
-/// Allows for the Int representation to be switched quickly
-/// Will maybe be non conformant to the JSON spec on 32bit machines
-/// Swift 3 will bring #if os(32bit) I think, that will be an approach to fix this.
+/**
+    Allows for the Int representation to be switched quickly
+    Will maybe be non conformant to the JSON spec on 32bit machines
+    Swift 3 will bring #if os(32bit) I think, that will be an approach to fix this.
+*/
 public typealias JSONInteger = Int
 
 /// Any value that can be expressed in JSON has a representation in `JSON`.
 public indirect enum JSON {
-	case object([String: JSON])
-	case array([JSON])
-	
-	case null
-	case bool(Bool)
-	case string(String)
-	case integer(JSONInteger)
-	case double(Double)
-	
-		/**
-	Turns a nested graph of `JSON`s into a Swift `String`. This produces JSON data that
-	strictly conforms to [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). 
-	TODO: It can optionally pretty-print the output for debugging, but this comes with a non-negligible performance cost.
-	*/
-	public func jsonString() throws -> String {
-		switch self {
-		case .array(let a):
-			var str = ""
-			for (i, v) in a.enumerate() {
-				str.appendContentsOf(try v.jsonString())
-				guard i != a.endIndex.predecessor() else { break }
-				str.appendContentsOf(",")
-			}
-			return "[" + str + "]"
-			
-		case .object(let o):
-			var str = ""
-			for (i, pair) in o.enumerate() {
-				let (key, value) = pair
-				let valueJSONString = try value.jsonString()
-				let keyPair = ["\"", key, "\":", valueJSONString].joinWithSeparator("")
-				str.appendContentsOf(keyPair)
-				guard i.successor() != o.count else { break }
-				str.appendContentsOf(",")
-			}
-			return "{" + str + "}"
-			
-		case .string(let s):
-			var output = ""
-			output.append(quotationMark)
-			var generator = s.unicodeScalars.generate()
-			while let scalar = generator.next() {
-				switch scalar.value {
-				case solidus.value:
-					fallthrough
-				case 0x0000...0x001F:
-					output.append(reverseSolidus)
-					switch scalar {
-					case tabCharacter:
-						output.appendContentsOf("t")
-					case carriageReturn:
-						output.appendContentsOf("r")
-					case lineFeed:
-						output.appendContentsOf("n")
-					case quotationMark:
-						output.append(quotationMark)
-					case backspace:
-						output.appendContentsOf("b")
-					case solidus:
-						output.append(solidus)
-					default:
-						output.appendContentsOf("u")
-						output.append(hexScalars[(Int(scalar.value) & 0xF000) >> 12])
-						output.append(hexScalars[(Int(scalar.value) & 0x0F00) >> 8])
-						output.append(hexScalars[(Int(scalar.value) & 0x00F0) >> 4])
-						output.append(hexScalars[(Int(scalar.value) & 0x000F) >> 0])
-					}
-				default:
-					output.append(scalar)
-				}
-			}
-			output.append(quotationMark)
-			return output
-			
-		case .null: return "null"
-		case .bool(let b): return b.description
-		case .integer(let i): return i.description
-		case .double(let f):
-			guard f.isFinite else {
-				throw JSONSerializeError.InvalidNumber
-			}
-			return f.description
-		}
-	}
-	
-	/// Returns this enum's associated Array value if it is one, `nil` otherwise.
-	public var array: [JSON]? {
-		guard case .array(let a) = self else { return nil }
-		return a
-	}
-	
-	/// Returns this enum's associated Dictionary value if it is one, `nil` otherwise.
-	public var object: [String: JSON]? {
-		guard case .object(let o) = self else { return nil }
-		return o
-	}
-	
-	/// Returns this enum's associated String value if it is one, `nil` otherwise.
-	public var string: String? {
-		guard case .string(let s) = self else { return nil }
-		return s
-	}
-	
-	/// Returns this enum's associated `JSONInteger` value if it is one, `nil` otherwise.
-	public var int: JSONInteger? {
-		guard case .integer(let i) = self else { return nil }
-		return i
-	}
-	
-	/// Returns this enum's associated Bool value if it is one, `nil` otherwise.
-	public var bool: Bool? {
-		guard case .bool(let b) = self else { return nil }
-		return b
-	}
-	
-	/// Returns this enum's associated Double value if it is one, `nil` otherwise.
-	public var double: Double? {
-		guard case .double(let d) = self else { return nil }
-		return d
-	}
+    case object([String: JSON])
+    case array([JSON])
+
+    case null
+    case bool(Bool)
+    case string(String)
+    case integer(JSONInteger)
+    case double(Double)
+
+    /**
+        Turns a nested graph of `JSON`s into a Swift `String`. This produces JSON data that
+        strictly conforms to [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+        TODO: It can optionally pretty-print the output for debugging, but this comes with a non-negligible performance cost.
+    */
+    public func jsonString() throws -> String {
+        switch self {
+        case .array(let a):
+            var str = ""
+            for (i, v) in a.enumerate() {
+                str.appendContentsOf(try v.jsonString())
+                guard i != a.endIndex.predecessor() else { break }
+                str.appendContentsOf(",")
+            }
+            return "[" + str + "]"
+
+        case .object(let o):
+            var str = ""
+            for (i, pair) in o.enumerate() {
+                let (key, value) = pair
+                let valueJSONString = try value.jsonString()
+                let keyPair = ["\"", key, "\":", valueJSONString].joinWithSeparator("")
+                str.appendContentsOf(keyPair)
+                guard i.successor() != o.count else { break }
+                str.appendContentsOf(",")
+            }
+            return "{" + str + "}"
+
+        case .string(let s):
+            var output = ""
+            output.append(quotationMark)
+            var generator = s.unicodeScalars.generate()
+            while let scalar = generator.next() {
+                switch scalar.value {
+                case solidus.value:
+                    fallthrough
+                case 0x0000...0x001F:
+                    output.append(reverseSolidus)
+                    switch scalar {
+                    case tabCharacter:
+                        output.appendContentsOf("t")
+                    case carriageReturn:
+                        output.appendContentsOf("r")
+                    case lineFeed:
+                        output.appendContentsOf("n")
+                    case quotationMark:
+                        output.append(quotationMark)
+                    case backspace:
+                        output.appendContentsOf("b")
+                    case solidus:
+                        output.append(solidus)
+                    default:
+                        output.appendContentsOf("u")
+                        output.append(hexScalars[(Int(scalar.value) & 0xF000) >> 12])
+                        output.append(hexScalars[(Int(scalar.value) & 0x0F00) >> 8])
+                        output.append(hexScalars[(Int(scalar.value) & 0x00F0) >> 4])
+                        output.append(hexScalars[(Int(scalar.value) & 0x000F) >> 0])
+                    }
+                default:
+                    output.append(scalar)
+                }
+            }
+            output.append(quotationMark)
+            return output
+
+        case .null: return "null"
+        case .bool(let b): return b.description
+        case .integer(let i): return i.description
+        case .double(let f):
+            guard f.isFinite else {
+                throw JSONSerializeError.InvalidNumber
+            }
+            return f.description
+        }
+    }
+
+    /// Returns this enum's associated Array value if it is one, `nil` otherwise.
+    public var array: [JSON]? {
+        guard case .array(let a) = self else { return nil }
+        return a
+    }
+
+    /// Returns this enum's associated Dictionary value if it is one, `nil` otherwise.
+    public var object: [String: JSON]? {
+        guard case .object(let o) = self else { return nil }
+        return o
+    }
+
+    /// Returns this enum's associated String value if it is one, `nil` otherwise.
+    public var string: String? {
+        guard case .string(let s) = self else { return nil }
+        return s
+    }
+
+    /// Returns this enum's associated `JSONInteger` value if it is one, `nil` otherwise.
+    public var int: JSONInteger? {
+        guard case .integer(let i) = self else { return nil }
+        return i
+    }
+
+    /// Returns this enum's associated Bool value if it is one, `nil` otherwise.
+    public var bool: Bool? {
+        guard case .bool(let b) = self else { return nil }
+        return b
+    }
+
+    /// Returns this enum's associated Double value if it is one, `nil` otherwise.
+    public var double: Double? {
+        guard case .double(let d) = self else { return nil }
+        return d
+    }
 }
 
 extension JSON: Equatable {}
 
 public func ==(lhs: JSON, rhs: JSON) -> Bool {
-	switch (lhs, rhs) {
-	case (.null, .null): return true
-	case (.bool(let l), .bool(let r)): return l == r
-	case (.array(let l), .array(let r)): return l == r
-	case (.string(let l), .string(let r)): return l == r
-	case (.object(let l), .object(let r)): return l == r
-	case (.integer(let l), .integer(let r)): return l == r
-	case (.double(let l), .double(let r)): return l == r
-		
-	default: return false
-	}
+    switch (lhs, rhs) {
+    case (.null, .null): return true
+    case (.bool(let l), .bool(let r)): return l == r
+    case (.array(let l), .array(let r)): return l == r
+    case (.string(let l), .string(let r)): return l == r
+    case (.object(let l), .object(let r)): return l == r
+    case (.integer(let l), .integer(let r)): return l == r
+    case (.double(let l), .double(let r)): return l == r
+
+    default: return false
+    }
 }
 
 extension JSON: IntegerLiteralConvertible {
-	public init(integerLiteral value: IntegerLiteralType) {
-		let val = JSONInteger(value)
-		self = .integer(val)
-	}
+    public init(integerLiteral value: IntegerLiteralType) {
+        let val = JSONInteger(value)
+        self = .integer(val)
+    }
 }
 
 extension JSON: FloatLiteralConvertible {
-	public init(floatLiteral value: FloatLiteralType) {
-		let val = Double(value)
-		self = .double(val)
-	}
+    public init(floatLiteral value: FloatLiteralType) {
+        let val = Double(value)
+        self = .double(val)
+    }
 }
 
 extension JSON : StringLiteralConvertible {
-	public init(stringLiteral value: String) {
-		self = .string(value)
-	}
-	
-	public init(extendedGraphemeClusterLiteral value: String) {
-		self = .string(value)
-	}
-	
-	public init(unicodeScalarLiteral value: String) {
-		self = .string(value)
-	}
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self = .string(value)
+    }
+
+    public init(unicodeScalarLiteral value: String) {
+        self = .string(value)
+    }
 }
 
 extension JSON : ArrayLiteralConvertible {
-	public init(arrayLiteral elements: JSON...) {
-		self = .array(elements)
-	}
+    public init(arrayLiteral elements: JSON...) {
+        self = .array(elements)
+    }
 }
 
 extension JSON : DictionaryLiteralConvertible {
-	public init(dictionaryLiteral elements: (String, JSON)...) {
-		var dict: [String: JSON] = [:]
-		for (k, v) in elements {
-			dict[k] = v
-		}
-		
-		self = .object(dict)
-	}
+    public init(dictionaryLiteral elements: (String, JSON)...) {
+        var dict: [String: JSON] = [:]
+        for (k, v) in elements {
+            dict[k] = v
+        }
+
+        self = .object(dict)
+    }
 }
 
 extension JSON : NilLiteralConvertible {
-	public init(nilLiteral: ()) {
-		self = .null
-	}
+    public init(nilLiteral: ()) {
+        self = .null
+    }
 }
 
 extension JSON: BooleanLiteralConvertible {
-	public init(booleanLiteral value: Bool) {
-		self = .bool(value)
-	}
+    public init(booleanLiteral value: Bool) {
+        self = .bool(value)
+    }
 }
 
 extension JSON {
-	init(string: String) throws {
-		self = .null
-	}
+    init(string: String) throws {
+        self = .null
+    }
 }
 
 // MARK:- JSON Accessors
 
 extension JSON {
-	/// Treat this JSON as a JSON object and attempt to get or set its
-	/// associated Dictionary values.
-	public subscript(key: String) -> JSON? {
-		get {
-			guard case .object(let o) = self else { return nil }
-			return o[key]
-		}
-		
-		set {
-			guard case .object(var o) = self else { return }
-			o[key] = newValue
-			self = .object(o)
-		}
-	}
-	
-	/// Treat this JSON as a JSON array and attempt to get or set its
-	/// associated Array values.
-	/// This will do nothing if you attempt to set outside of bounds.
-	public subscript(index: Int) -> JSON? {
-		get {
-			guard case .array(let a) = self where a.indices ~= index else { return nil }
-			return a[index]
-		}
-		
-		set {
-			guard case .array(var a) = self where a.indices ~= index else { return }
-			switch newValue {
-			case .Some(let newValue):
-				a[index] = newValue
-				
-			case .None:
-				a.removeAtIndex(index)
-			}
-			self = .array(a)
-		}
-	}
+    /**
+        Treat this JSON as a JSON object and attempt to get or set its
+        associated Dictionary values.
+    */
+    public subscript(key: String) -> JSON? {
+        get {
+            guard case .object(let o) = self else { return nil }
+            return o[key]
+        }
+
+        set {
+            guard case .object(var o) = self else { return }
+            o[key] = newValue
+            self = .object(o)
+        }
+    }
+
+    /*
+        Treat this JSON as a JSON array and attempt to get or set its
+        associated Array values.
+        This will do nothing if you attempt to set outside of bounds.
+    */
+    public subscript(index: Int) -> JSON? {
+        get {
+            guard case .array(let a) = self where a.indices ~= index else { return nil }
+            return a[index]
+        }
+
+        set {
+            guard case .array(var a) = self where a.indices ~= index else { return }
+            switch newValue {
+            case .Some(let newValue):
+                a[index] = newValue
+
+            case .None:
+                a.removeAtIndex(index)
+            }
+            self = .array(a)
+        }
+    }
 }
 
-/// WARNING: Internal type. Used to constrain an extension on Optional
-/// to be sudo non Generic. 
-/// *DO NOT USE* outside of JSONCore
+/**
+    WARNING: Internal type. Used to constrain an extension on Optional
+    to be sudo non Generic.
+    *DO NOT USE* outside of JSONCore
+*/
 public protocol _JSONType {}
 extension JSON: _JSONType {}
 
 // TODO: Support set through these subscripts
 extension Optional where Wrapped: _JSONType {
-	/// Treat this Optional<_JSONType> as a JSON object and attempt to get its
-	/// associated Dictionary values.
-	/// Will return `nil` in the following cases:
-	/// - The JSON is not an object
-	/// - A value for the key is not found on the object
-	/// - The `Wrapped.type` != `JSON.type`
-	public subscript(key: String) -> JSON? {
-		// TODO(ethan): find a better way, should we fatalError() if it isn't `JSON`
-		// Would be best if we could constrain extensions to be Non-Generic. Swift3?
-		guard let o = (self as? JSON)?.object else { return nil }
-		return o[key]
-	}
-	
-	/// Treat this Optional<_JSONType> as a JSON array and attempt to get its
-	/// associated Array values.
-	/// Will return `nil` in the following cases:
-	/// - The JSON is not an array
-	/// - The index is outside of the array bounds
-	/// - The `Wrapped.type` != `JSON.type`
-	public subscript(index: Int) -> JSON? {
-		guard let a = (self as? JSON)?.array where a.indices ~= index else { return nil }
-		return a[index]
-	}
+    /// returns the `JSON` value for key iff `Wrapped` is `JSON.object` and there is a value for the key
+    public subscript(key: String) -> JSON? {
+        // TODO(ethan): find a better way, should we fatalError() if it isn't `JSON`
+        // Would be best if we could constrain extensions to be Non-Generic. Swift3?
+        guard let o = (self as? JSON)?.object else { return nil }
+        return o[key]
+    }
+
+    /// returns the JSON value at index iff `Wrapped` is `JSON.array` and the index is within the arrays bounds
+    public subscript(index: Int) -> JSON? {
+        guard let a = (self as? JSON)?.array where a.indices ~= index else { return nil }
+        return a[index]
+    }
+
+    /// Returns an array of `JSON` iff `Wrapped` is `JSON.array`
+    public var array: [JSON]? {
+        guard let a = (self as? JSON)?.array else { return nil }
+        return a
+    }
+
+    /// Returns a `JSON` object iff `Wrapped` is `JSON.object`
+    public var object: [String: JSON]? {
+        guard let o = (self as? JSON)?.object else { return nil }
+        return o
+    }
+
+    /// Returns a `String` iff `Wrapped` is `JSON.string`
+    public var string: String? {
+        guard let s = (self as? JSON)?.string else { return nil }
+        return s
+    }
+
+    /// Returns a `JSONInteger` iff `Wrapped` is `JSON.integer`
+    public var int: JSONInteger? {
+        guard let i = (self as? JSON)?.int else { return nil }
+        return i
+    }
+
+    /// Returns a `Bool` iff `Wrapped` is `JSON.bool`
+    public var bool: Bool? {
+        guard let b = (self as? JSON)?.bool else { return nil }
+        return b
+    }
+
+    /// Returns a `Double` iff `Wrapped` is `JSON.double`
+    public var double: Double? {
+        guard let d = (self as? JSON)?.double else { return nil }
+        return d
+    }
 }
 
 // MARK:- Parser
 public enum JSONParseError: ErrorType {
-	/// Some unknown error, usually indicates something not yet implemented.
-	case Unknown
-	/// Input data was either empty or contained only whitespace.
-	case EmptyInput
-	/// Some character that violates the strict JSON grammar was found.
-	case UnexpectedCharacter(lineNumber: UInt, characterNumber: UInt)
-	/// A JSON string was opened but never closed.
-	case UnterminatedString
-	/// Any unicode parsing errors will result in this error. Currently unused.
-	case InvalidUnicode
-	/// A keyword, like `null`, `true`, or `false` was expected but something else was in the input.
-	case UnexpectedKeyword(lineNumber: UInt, characterNumber: UInt)
-	/// Encountered a JSON number that couldn't be losslessly stored in a `Double` or `Int64`.
-	/// Usually the number is too large or too small.
-	case InvalidNumber(lineNumber: UInt, characterNumber: UInt)
-	/// End of file reached, not always an actual error.
-	case EndOfFile
+    /// Some unknown error, usually indicates something not yet implemented.
+    case Unknown
+    /// Input data was either empty or contained only whitespace.
+    case EmptyInput
+    /// Some character that violates the strict JSON grammar was found.
+    case UnexpectedCharacter(lineNumber: UInt, characterNumber: UInt)
+    /// A JSON string was opened but never closed.
+    case UnterminatedString
+    /// Any unicode parsing errors will result in this error. Currently unused.
+    case InvalidUnicode
+    /// A keyword, like `null`, `true`, or `false` was expected but something else was in the input.
+    case UnexpectedKeyword(lineNumber: UInt, characterNumber: UInt)
+    /// Encountered a JSON number that couldn't be losslessly stored in a `Double` or `Int64`.
+    /// Usually the number is too large or too small.
+    case InvalidNumber(lineNumber: UInt, characterNumber: UInt)
+    /// End of file reached, not always an actual error.
+    case EndOfFile
 }
 
 // MARK:- Parser
@@ -333,494 +367,494 @@ of `JSON`s. This is a strict parser implementing [ECMA-404](http://www.ecma-inte
 Being strict, it doesn't support common JSON extensions such as comments.
 */
 public class JSONParser {
-	/**
-	A shortcut for creating a `JSONParser` and having it parse the given data.
-	This is a blocking operation, and will block the calling thread until parsing
-	finishes or throws an error.
-	- Parameter data: The Unicode scalars representing the input JSON data.
-	- Returns: The root `JSON` node from the input data.
-	- Throws: A `JSONParseError` if something failed during parsing.
-	*/
-	public class func parse(data: String.UnicodeScalarView) throws -> JSON {
-		let parser = JSONParser(data: data)
-		return try parser.parse()
-	}
-	
-	/**
-	A shortcut for creating a `JSONParser` and having it parse the given `String`.
-	This is a blocking operation, and will block the calling thread until parsing
-	finishes or throws an error.
-	- Parameter string: The `String` of the input JSON.
-	- Returns: The root `JSON` node from the input data.
-	- Throws: A `JSONParseError` if something failed during parsing.
-	*/
-	public class func parse(string: String) throws -> JSON {
-		let parser = JSONParser(data: string.unicodeScalars)
-		return try parser.parse()
-	}
-	
-	/**
-	Designated initializer for `JSONParser`, which requires an input Unicode scalar
-	collection.
-	- Parameter data: The Unicode scalars representing the input JSON data.
-	*/
-	public init(data: String.UnicodeScalarView) {
-		generator = data.generate()
-		self.data = data
-	}
-	
-	/**
-	Starts parsing the data. This is a blocking operation, and will block the
-	calling thread until parsing finishes or throws an error.
-	- Returns: The root `JSON` node from the input data.
-	- Throws: A `JSONParseError` if something failed during parsing.
-	*/
-	public func parse() throws -> JSON {
-		do {
-			try nextScalar()
-			let value = try nextValue()
-			do {
-				try nextScalar()
-				let v = scalar.value
-				if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-					// Skip to EOF or the next token
-					try skipToNextToken()
-					// If we get this far some token was found ...
-					throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-				} else {
-					// There's some weird character at the end of the file...
-					throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-				}
-			} catch JSONParseError.EndOfFile {
-				return value
-			}
-		} catch JSONParseError.EndOfFile {
-			throw JSONParseError.EmptyInput
-		}
-	}
-	
-	// MARK: - Internals: Properties
-	
-	var generator: String.UnicodeScalarView.Generator
-	let data: String.UnicodeScalarView
-	var scalar: UnicodeScalar!
-	var lineNumber: UInt = 0
-	var charNumber: UInt = 0
-	
-	var crlfHack = false
-	
+    /**
+    A shortcut for creating a `JSONParser` and having it parse the given data.
+    This is a blocking operation, and will block the calling thread until parsing
+    finishes or throws an error.
+    - Parameter data: The Unicode scalars representing the input JSON data.
+    - Returns: The root `JSON` node from the input data.
+    - Throws: A `JSONParseError` if something failed during parsing.
+    */
+    public class func parse(data: String.UnicodeScalarView) throws -> JSON {
+        let parser = JSONParser(data: data)
+        return try parser.parse()
+    }
+
+    /**
+    A shortcut for creating a `JSONParser` and having it parse the given `String`.
+    This is a blocking operation, and will block the calling thread until parsing
+    finishes or throws an error.
+    - Parameter string: The `String` of the input JSON.
+    - Returns: The root `JSON` node from the input data.
+    - Throws: A `JSONParseError` if something failed during parsing.
+    */
+    public class func parse(string: String) throws -> JSON {
+        let parser = JSONParser(data: string.unicodeScalars)
+        return try parser.parse()
+    }
+
+    /**
+    Designated initializer for `JSONParser`, which requires an input Unicode scalar
+    collection.
+    - Parameter data: The Unicode scalars representing the input JSON data.
+    */
+    public init(data: String.UnicodeScalarView) {
+        generator = data.generate()
+        self.data = data
+    }
+
+    /**
+    Starts parsing the data. This is a blocking operation, and will block the
+    calling thread until parsing finishes or throws an error.
+    - Returns: The root `JSON` node from the input data.
+    - Throws: A `JSONParseError` if something failed during parsing.
+    */
+    public func parse() throws -> JSON {
+        do {
+            try nextScalar()
+            let value = try nextValue()
+            do {
+                try nextScalar()
+                let v = scalar.value
+                if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+                    // Skip to EOF or the next token
+                    try skipToNextToken()
+                    // If we get this far some token was found ...
+                    throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+                } else {
+                    // There's some weird character at the end of the file...
+                    throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+                }
+            } catch JSONParseError.EndOfFile {
+                return value
+            }
+        } catch JSONParseError.EndOfFile {
+            throw JSONParseError.EmptyInput
+        }
+    }
+
+    // MARK: - Internals: Properties
+
+    var generator: String.UnicodeScalarView.Generator
+    let data: String.UnicodeScalarView
+    var scalar: UnicodeScalar!
+    var lineNumber: UInt = 0
+    var charNumber: UInt = 0
+
+    var crlfHack = false
+
 }
 
 // MARK: JSONParser Internals
 extension JSONParser {
-	// MARK: - Enumerating the scalar collection
-	func nextScalar() throws {
-		if let sc = generator.next() {
-			scalar = sc
-			charNumber = charNumber + 1
-			if crlfHack == true && sc != lineFeed {
-				crlfHack = false
-			}
-		} else {
-			throw JSONParseError.EndOfFile
-		}
-	}
-	
-	func skipToNextToken() throws {
-		var v = scalar.value
-		if v != 0x0009 && v != 0x000A && v != 0x000D && v != 0x0020 {
-			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-		}
-		
-		while v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-			if scalar == carriageReturn || scalar == lineFeed {
-				if crlfHack == true && scalar == lineFeed {
-					crlfHack = false
-					charNumber = 0
-				} else {
-					if (scalar == carriageReturn) {
-						crlfHack = true
-					}
-					lineNumber = lineNumber + 1
-					charNumber = 0
-				}
-			}
-			try nextScalar()
-			v = scalar.value
-		}
-	}
-	
-	func nextScalars(count: UInt) throws -> [UnicodeScalar] {
-		var values = [UnicodeScalar]()
-		values.reserveCapacity(Int(count))
-		for _ in 0..<count {
-			try nextScalar()
-			values.append(scalar)
-		}
-		return values
-	}
-	
-	// MARK: - Parse loop
-	func nextValue() throws -> JSON {
-		let v = scalar.value
-		if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-			try skipToNextToken()
-		}
-		switch scalar {
-		case leftCurlyBracket:
-			return try nextObject()
-		case leftSquareBracket:
-			return try nextArray()
-		case quotationMark:
-			return try nextString()
-		case trueToken[0], falseToken[0]:
-			return try nextBool()
-		case nullToken[0]:
-			return try nextNull()
-		case "0".unicodeScalars.first!..."9".unicodeScalars.first!,negativeScalar,decimalScalar:
-			return try nextNumber()
-		default:
-			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-		}
-	}
-	
-	// MARK: - Parse a specific, expected type
-	func nextObject() throws -> JSON {
-		if scalar != leftCurlyBracket {
-			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-		}
-		var dictBuilder = [String : JSON]()
-		try nextScalar()
-		if scalar == rightCurlyBracket {
-			// Empty object
-			return JSON.object(dictBuilder)
-		}
-		outerLoop: repeat {
-			var v = scalar.value
-			if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-				try skipToNextToken()
-			}
-			let string = try nextString()
-			try nextScalar() // Skip the quotation character
-			v = scalar.value
-			if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-				try skipToNextToken()
-			}
-			if scalar != colon {
-				throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-			}
-			try nextScalar() // Skip the ':'
-			let value = try nextValue()
-			switch value {
-			// Skip the closing character for all values except number, which doesn't have one
-			case .integer, .double:
-				break
-			default:
-				try nextScalar()
-			}
-			v = scalar.value
-			if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-				try skipToNextToken()
-			}
-			guard case .string(let key) = string else { throw JSONParseError.Unknown }
-			//let key = string.string! // We're pretty confident it's a string since we called nextString() above
-			dictBuilder[key] = value
-			switch scalar {
-			case rightCurlyBracket:
-				break outerLoop
-			case comma:
-				try nextScalar()
-			default:
-				throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-			}
-			
-		} while true
-		return JSON.object(dictBuilder)
-	}
-	
-	func nextArray() throws -> JSON {
-		if scalar != leftSquareBracket {
-			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-		}
-		var arrBuilder = [JSON]()
-		try nextScalar()
-		if scalar == rightSquareBracket {
-			// Empty array
-			return JSON.array(arrBuilder)
-		}
-		outerLoop: repeat {
-			let value = try nextValue()
-			arrBuilder.append(value)
-			switch value {
-			// Skip the closing character for all values except number, which doesn't have one
-			case .integer, .double:
-				break
-			default:
-				try nextScalar()
-			}
-			let v = scalar.value
-			if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-				try skipToNextToken()
-			}
-			switch scalar {
-			case rightSquareBracket:
-				break outerLoop
-			case comma:
-				try nextScalar()
-			default:
-				throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-			}
-		} while true
-		
-		return JSON.array(arrBuilder)
-	}
-	
-	func nextString() throws -> JSON {
-		if scalar != quotationMark {
-			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-		}
-		try nextScalar() // Skip pas the quotation character
-		var strBuilder = ""
-		var escaping = false
-		outerLoop: repeat {
-			// First we should deal with the escape character and the terminating quote
-			switch scalar {
-			case reverseSolidus:
-				// Escape character
-				if escaping {
-					// Escaping the escape char
-					strBuilder.append(reverseSolidus)
-				}
-				escaping = !escaping
-				try nextScalar()
-			case quotationMark:
-				if escaping {
-					strBuilder.append(quotationMark)
-					escaping = false
-					try nextScalar()
-				} else {
-					break outerLoop
-				}
-			default:
-				// Now the rest
-				if escaping {
-					// Handle all the different escape characters
-					if let s = escapeMap[scalar] {
-						strBuilder.append(s)
-						try nextScalar()
-					} else if scalar == "u".unicodeScalars.first! {
-						let escapedUnicodeValue = try nextUnicodeEscape()
-						strBuilder.append(UnicodeScalar(escapedUnicodeValue))
-						try nextScalar()
-					}
-					escaping = false
-				} else {
-					// Simple append
-					strBuilder.append(scalar)
-					try nextScalar()
-				}
-			}
-		} while true
-		return JSON.string(strBuilder)
-	}
-	
-	func nextUnicodeEscape() throws -> UInt32 {
-		if scalar != "u".unicodeScalars.first! {
-			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-		}
-		var readScalar = UInt32(0)
-		for _ in 0...3 {
-			readScalar = readScalar * 16
-			try nextScalar()
-			if ("0".unicodeScalars.first!..."9".unicodeScalars.first!).contains(scalar) {
-				readScalar = readScalar + UInt32(scalar.value - "0".unicodeScalars.first!.value)
-			} else if ("a".unicodeScalars.first!..."f".unicodeScalars.first!).contains(scalar) {
-				let aScalarVal = "a".unicodeScalars.first!.value
-				let hexVal = scalar.value - aScalarVal
-				let hexScalarVal = hexVal + 10
-				readScalar = readScalar + hexScalarVal
-			} else if ("A".unicodeScalars.first!..."F".unicodeScalars.first!).contains(scalar) {
-				let aScalarVal = "A".unicodeScalars.first!.value
-				let hexVal = scalar.value - aScalarVal
-				let hexScalarVal = hexVal + 10
-				readScalar = readScalar + hexScalarVal
-			} else {
-				throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-			}
-		}
-		if readScalar >= 0xD800 && readScalar <= 0xDBFF {
-			// UTF-16 surrogate pair
-			// The next character MUST be the other half of the surrogate pair
-			// Otherwise it's a unicode error
-			do {
-				try nextScalar()
-				if scalar != reverseSolidus {
-					throw JSONParseError.InvalidUnicode
-				}
-				try nextScalar()
-				let secondScalar = try nextUnicodeEscape()
-				if secondScalar < 0xDC00 || secondScalar > 0xDFFF {
-					throw JSONParseError.InvalidUnicode
-				}
-				let actualScalar = ((readScalar - 0xD800) * 0x400) + ((secondScalar - 0xDC00) + 0x10000)
-				return actualScalar
-			} catch JSONParseError.UnexpectedCharacter {
-				throw JSONParseError.InvalidUnicode
-			}
-		}
-		return readScalar
-	}
-	
-	func nextNumber() throws -> JSON {
-		var isNegative = false
-		var hasDecimal = false
-		var hasDigits = false
-		var hasExponent = false
-		var positiveExponent = false
-		var exponent = 0
-		var integer: UInt64 = 0
-		var decimal: Int64 = 0
-		var divisor: Double = 10
-		let lineNumAtStart = lineNumber
-		let charNumAtStart = charNumber
-		
-		do {
-			outerLoop: repeat {
-				switch scalar {
-				case "0".unicodeScalars.first!..."9".unicodeScalars.first!:
-					hasDigits = true
-					if hasDecimal {
-						decimal *= 10
-						decimal += Int64(scalar.value - zeroScalar.value)
-						divisor *= 10
-					} else {
-						integer *= 10
-						integer += UInt64(scalar.value - zeroScalar.value)
-					}
-					try nextScalar()
-				case negativeScalar:
-					if hasDigits || hasDecimal || hasDigits || isNegative {
-						throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-					} else {
-						isNegative = true
-					}
-					try nextScalar()
-				case decimalScalar:
-					if hasDecimal {
-						throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-					} else {
-						hasDecimal = true
-					}
-					try nextScalar()
-				case "e".unicodeScalars.first!,"E".unicodeScalars.first!:
-					if hasExponent {
-						throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-					} else {
-						hasExponent = true
-					}
-					try nextScalar()
-					switch scalar {
-					case "0".unicodeScalars.first!..."9".unicodeScalars.first!:
-						positiveExponent = true
-					case plusScalar:
-						positiveExponent = true
-						try nextScalar()
-					case negativeScalar:
-						positiveExponent = false
-						try nextScalar()
-					default:
-						throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-					}
-					exponentLoop: repeat {
-						if scalar.value >= zeroScalar.value && scalar.value <= "9".unicodeScalars.first!.value {
-							exponent *= 10
-							exponent += Int(scalar.value - zeroScalar.value)
-							try nextScalar()
-						} else {
-							break exponentLoop
-						}
-					} while true
-				default:
-					break outerLoop
-				}
-			} while true
-		} catch JSONParseError.EndOfFile {
-			// This is fine
-		}
-		
-		if !hasDigits {
-			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-		}
-		
-		let sign = isNegative ? -1 : 1
-		if hasDecimal || hasExponent {
-			divisor /= 10
-			var number = Double(sign) * (Double(integer) + (Double(decimal) / divisor))
-			if hasExponent {
-				if positiveExponent {
-					for _ in 1...exponent {
-						number *= Double(10)
-					}
-				} else {
-					for _ in 1...exponent {
-						number /= Double(10)
-					}
-				}
-			}
-			return JSON.double(number)
-		} else {
-			var number: Int64
-			if isNegative {
-				if integer > UInt64(Int64.max) + 1 {
-					throw JSONParseError.InvalidNumber(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
-				} else if integer == UInt64(Int64.max) + 1 {
-					number = Int64.min
-				} else {
-					number = Int64(integer) * -1
-				}
-			} else {
-				if integer > UInt64(Int64.max) {
-					throw JSONParseError.InvalidNumber(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
-				} else {
-					number = Int64(integer)
-				}
-			}
-			return JSON.integer(JSONInteger(number))
-		}
-	}
-	
-	func nextBool() throws -> JSON {
-		var expectedWord: [UnicodeScalar]
-		var expectedBool: Bool
-		let lineNumAtStart = lineNumber
-		let charNumAtStart = charNumber
-		if scalar == trueToken[0] {
-			expectedWord = trueToken
-			expectedBool = true
-		} else if scalar == falseToken[0] {
-			expectedWord = falseToken
-			expectedBool = false
-		} else {
-			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-		}
-		do {
-			let word = try [scalar] + nextScalars(UInt(expectedWord.count - 1))
-			if word != expectedWord {
-				throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
-			}
-		} catch JSONParseError.EndOfFile {
-			throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
-		}
-		return JSON.bool(expectedBool)
-	}
-	
-	func nextNull() throws -> JSON {
-		let word = try [scalar] + nextScalars(3)
-		if word != nullToken {
-			throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumber, characterNumber: charNumber-4)
-		}
-		return JSON.null
-	}
+    // MARK: - Enumerating the scalar collection
+    func nextScalar() throws {
+        if let sc = generator.next() {
+            scalar = sc
+            charNumber = charNumber + 1
+            if crlfHack == true && sc != lineFeed {
+                crlfHack = false
+            }
+        } else {
+            throw JSONParseError.EndOfFile
+        }
+    }
+
+    func skipToNextToken() throws {
+        var v = scalar.value
+        if v != 0x0009 && v != 0x000A && v != 0x000D && v != 0x0020 {
+            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+        }
+
+        while v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+            if scalar == carriageReturn || scalar == lineFeed {
+                if crlfHack == true && scalar == lineFeed {
+                    crlfHack = false
+                    charNumber = 0
+                } else {
+                    if (scalar == carriageReturn) {
+                        crlfHack = true
+                    }
+                    lineNumber = lineNumber + 1
+                    charNumber = 0
+                }
+            }
+            try nextScalar()
+            v = scalar.value
+        }
+    }
+
+    func nextScalars(count: UInt) throws -> [UnicodeScalar] {
+        var values = [UnicodeScalar]()
+        values.reserveCapacity(Int(count))
+        for _ in 0..<count {
+            try nextScalar()
+            values.append(scalar)
+        }
+        return values
+    }
+
+    // MARK: - Parse loop
+    func nextValue() throws -> JSON {
+        let v = scalar.value
+        if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+            try skipToNextToken()
+        }
+        switch scalar {
+        case leftCurlyBracket:
+            return try nextObject()
+        case leftSquareBracket:
+            return try nextArray()
+        case quotationMark:
+            return try nextString()
+        case trueToken[0], falseToken[0]:
+            return try nextBool()
+        case nullToken[0]:
+            return try nextNull()
+        case "0".unicodeScalars.first!..."9".unicodeScalars.first!,negativeScalar,decimalScalar:
+            return try nextNumber()
+        default:
+            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+        }
+    }
+
+    // MARK: - Parse a specific, expected type
+    func nextObject() throws -> JSON {
+        if scalar != leftCurlyBracket {
+            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+        }
+        var dictBuilder = [String : JSON]()
+        try nextScalar()
+        if scalar == rightCurlyBracket {
+            // Empty object
+            return JSON.object(dictBuilder)
+        }
+        outerLoop: repeat {
+            var v = scalar.value
+            if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+                try skipToNextToken()
+            }
+            let string = try nextString()
+            try nextScalar() // Skip the quotation character
+            v = scalar.value
+            if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+                try skipToNextToken()
+            }
+            if scalar != colon {
+                throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+            }
+            try nextScalar() // Skip the ':'
+            let value = try nextValue()
+            switch value {
+            // Skip the closing character for all values except number, which doesn't have one
+            case .integer, .double:
+                break
+            default:
+                try nextScalar()
+            }
+            v = scalar.value
+            if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+                try skipToNextToken()
+            }
+            guard case .string(let key) = string else { throw JSONParseError.Unknown }
+            //let key = string.string! // We're pretty confident it's a string since we called nextString() above
+            dictBuilder[key] = value
+            switch scalar {
+            case rightCurlyBracket:
+                break outerLoop
+            case comma:
+                try nextScalar()
+            default:
+                throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+            }
+
+        } while true
+        return JSON.object(dictBuilder)
+    }
+
+    func nextArray() throws -> JSON {
+        if scalar != leftSquareBracket {
+            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+        }
+        var arrBuilder = [JSON]()
+        try nextScalar()
+        if scalar == rightSquareBracket {
+            // Empty array
+            return JSON.array(arrBuilder)
+        }
+        outerLoop: repeat {
+            let value = try nextValue()
+            arrBuilder.append(value)
+            switch value {
+            // Skip the closing character for all values except number, which doesn't have one
+            case .integer, .double:
+                break
+            default:
+                try nextScalar()
+            }
+            let v = scalar.value
+            if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+                try skipToNextToken()
+            }
+            switch scalar {
+            case rightSquareBracket:
+                break outerLoop
+            case comma:
+                try nextScalar()
+            default:
+                throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+            }
+        } while true
+
+        return JSON.array(arrBuilder)
+    }
+
+    func nextString() throws -> JSON {
+        if scalar != quotationMark {
+            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+        }
+        try nextScalar() // Skip pas the quotation character
+        var strBuilder = ""
+        var escaping = false
+        outerLoop: repeat {
+            // First we should deal with the escape character and the terminating quote
+            switch scalar {
+            case reverseSolidus:
+                // Escape character
+                if escaping {
+                    // Escaping the escape char
+                    strBuilder.append(reverseSolidus)
+                }
+                escaping = !escaping
+                try nextScalar()
+            case quotationMark:
+                if escaping {
+                    strBuilder.append(quotationMark)
+                    escaping = false
+                    try nextScalar()
+                } else {
+                    break outerLoop
+                }
+            default:
+                // Now the rest
+                if escaping {
+                    // Handle all the different escape characters
+                    if let s = escapeMap[scalar] {
+                        strBuilder.append(s)
+                        try nextScalar()
+                    } else if scalar == "u".unicodeScalars.first! {
+                        let escapedUnicodeValue = try nextUnicodeEscape()
+                        strBuilder.append(UnicodeScalar(escapedUnicodeValue))
+                        try nextScalar()
+                    }
+                    escaping = false
+                } else {
+                    // Simple append
+                    strBuilder.append(scalar)
+                    try nextScalar()
+                }
+            }
+        } while true
+        return JSON.string(strBuilder)
+    }
+
+    func nextUnicodeEscape() throws -> UInt32 {
+        if scalar != "u".unicodeScalars.first! {
+            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+        }
+        var readScalar = UInt32(0)
+        for _ in 0...3 {
+            readScalar = readScalar * 16
+            try nextScalar()
+            if ("0".unicodeScalars.first!..."9".unicodeScalars.first!).contains(scalar) {
+                readScalar = readScalar + UInt32(scalar.value - "0".unicodeScalars.first!.value)
+            } else if ("a".unicodeScalars.first!..."f".unicodeScalars.first!).contains(scalar) {
+                let aScalarVal = "a".unicodeScalars.first!.value
+                let hexVal = scalar.value - aScalarVal
+                let hexScalarVal = hexVal + 10
+                readScalar = readScalar + hexScalarVal
+            } else if ("A".unicodeScalars.first!..."F".unicodeScalars.first!).contains(scalar) {
+                let aScalarVal = "A".unicodeScalars.first!.value
+                let hexVal = scalar.value - aScalarVal
+                let hexScalarVal = hexVal + 10
+                readScalar = readScalar + hexScalarVal
+            } else {
+                throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+            }
+        }
+        if readScalar >= 0xD800 && readScalar <= 0xDBFF {
+            // UTF-16 surrogate pair
+            // The next character MUST be the other half of the surrogate pair
+            // Otherwise it's a unicode error
+            do {
+                try nextScalar()
+                if scalar != reverseSolidus {
+                    throw JSONParseError.InvalidUnicode
+                }
+                try nextScalar()
+                let secondScalar = try nextUnicodeEscape()
+                if secondScalar < 0xDC00 || secondScalar > 0xDFFF {
+                    throw JSONParseError.InvalidUnicode
+                }
+                let actualScalar = ((readScalar - 0xD800) * 0x400) + ((secondScalar - 0xDC00) + 0x10000)
+                return actualScalar
+            } catch JSONParseError.UnexpectedCharacter {
+                throw JSONParseError.InvalidUnicode
+            }
+        }
+        return readScalar
+    }
+
+    func nextNumber() throws -> JSON {
+        var isNegative = false
+        var hasDecimal = false
+        var hasDigits = false
+        var hasExponent = false
+        var positiveExponent = false
+        var exponent = 0
+        var integer: UInt64 = 0
+        var decimal: Int64 = 0
+        var divisor: Double = 10
+        let lineNumAtStart = lineNumber
+        let charNumAtStart = charNumber
+
+        do {
+            outerLoop: repeat {
+                switch scalar {
+                case "0".unicodeScalars.first!..."9".unicodeScalars.first!:
+                    hasDigits = true
+                    if hasDecimal {
+                        decimal *= 10
+                        decimal += Int64(scalar.value - zeroScalar.value)
+                        divisor *= 10
+                    } else {
+                        integer *= 10
+                        integer += UInt64(scalar.value - zeroScalar.value)
+                    }
+                    try nextScalar()
+                case negativeScalar:
+                    if hasDigits || hasDecimal || hasDigits || isNegative {
+                        throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+                    } else {
+                        isNegative = true
+                    }
+                    try nextScalar()
+                case decimalScalar:
+                    if hasDecimal {
+                        throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+                    } else {
+                        hasDecimal = true
+                    }
+                    try nextScalar()
+                case "e".unicodeScalars.first!,"E".unicodeScalars.first!:
+                    if hasExponent {
+                        throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+                    } else {
+                        hasExponent = true
+                    }
+                    try nextScalar()
+                    switch scalar {
+                    case "0".unicodeScalars.first!..."9".unicodeScalars.first!:
+                        positiveExponent = true
+                    case plusScalar:
+                        positiveExponent = true
+                        try nextScalar()
+                    case negativeScalar:
+                        positiveExponent = false
+                        try nextScalar()
+                    default:
+                        throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+                    }
+                    exponentLoop: repeat {
+                        if scalar.value >= zeroScalar.value && scalar.value <= "9".unicodeScalars.first!.value {
+                            exponent *= 10
+                            exponent += Int(scalar.value - zeroScalar.value)
+                            try nextScalar()
+                        } else {
+                            break exponentLoop
+                        }
+                    } while true
+                default:
+                    break outerLoop
+                }
+            } while true
+        } catch JSONParseError.EndOfFile {
+            // This is fine
+        }
+
+        if !hasDigits {
+            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+        }
+
+        let sign = isNegative ? -1 : 1
+        if hasDecimal || hasExponent {
+            divisor /= 10
+            var number = Double(sign) * (Double(integer) + (Double(decimal) / divisor))
+            if hasExponent {
+                if positiveExponent {
+                    for _ in 1...exponent {
+                        number *= Double(10)
+                    }
+                } else {
+                    for _ in 1...exponent {
+                        number /= Double(10)
+                    }
+                }
+            }
+            return JSON.double(number)
+        } else {
+            var number: Int64
+            if isNegative {
+                if integer > UInt64(Int64.max) + 1 {
+                    throw JSONParseError.InvalidNumber(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
+                } else if integer == UInt64(Int64.max) + 1 {
+                    number = Int64.min
+                } else {
+                    number = Int64(integer) * -1
+                }
+            } else {
+                if integer > UInt64(Int64.max) {
+                    throw JSONParseError.InvalidNumber(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
+                } else {
+                    number = Int64(integer)
+                }
+            }
+            return JSON.integer(JSONInteger(number))
+        }
+    }
+
+    func nextBool() throws -> JSON {
+        var expectedWord: [UnicodeScalar]
+        var expectedBool: Bool
+        let lineNumAtStart = lineNumber
+        let charNumAtStart = charNumber
+        if scalar == trueToken[0] {
+            expectedWord = trueToken
+            expectedBool = true
+        } else if scalar == falseToken[0] {
+            expectedWord = falseToken
+            expectedBool = false
+        } else {
+            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+        }
+        do {
+            let word = try [scalar] + nextScalars(UInt(expectedWord.count - 1))
+            if word != expectedWord {
+                throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
+            }
+        } catch JSONParseError.EndOfFile {
+            throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
+        }
+        return JSON.bool(expectedBool)
+    }
+
+    func nextNull() throws -> JSON {
+        let word = try [scalar] + nextScalars(3)
+        if word != nullToken {
+            throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumber, characterNumber: charNumber-4)
+        }
+        return JSON.null
+    }
 }
 
 // MARK:- Unicode Scalars
@@ -851,30 +885,30 @@ private let falseToken = [UnicodeScalar]("false".unicodeScalars)
 private let nullToken = [UnicodeScalar]("null".unicodeScalars)
 
 private let escapeMap = [
-	"/".unicodeScalars.first!: solidus,
-	"b".unicodeScalars.first!: backspace,
-	"f".unicodeScalars.first!: formFeed,
-	"n".unicodeScalars.first!: lineFeed,
-	"r".unicodeScalars.first!: carriageReturn,
-	"t".unicodeScalars.first!: tabCharacter
+    "/".unicodeScalars.first!: solidus,
+    "b".unicodeScalars.first!: backspace,
+    "f".unicodeScalars.first!: formFeed,
+    "n".unicodeScalars.first!: lineFeed,
+    "r".unicodeScalars.first!: carriageReturn,
+    "t".unicodeScalars.first!: tabCharacter
 ]
 
 private let hexScalars = [
-	"0".unicodeScalars.first!,
-	"1".unicodeScalars.first!,
-	"2".unicodeScalars.first!,
-	"3".unicodeScalars.first!,
-	"4".unicodeScalars.first!,
-	"5".unicodeScalars.first!,
-	"6".unicodeScalars.first!,
-	"7".unicodeScalars.first!,
-	"8".unicodeScalars.first!,
-	"9".unicodeScalars.first!,
-	"a".unicodeScalars.first!,
-	"b".unicodeScalars.first!,
-	"c".unicodeScalars.first!,
-	"d".unicodeScalars.first!,
-	"e".unicodeScalars.first!,
-	"f".unicodeScalars.first!
+    "0".unicodeScalars.first!,
+    "1".unicodeScalars.first!,
+    "2".unicodeScalars.first!,
+    "3".unicodeScalars.first!,
+    "4".unicodeScalars.first!,
+    "5".unicodeScalars.first!,
+    "6".unicodeScalars.first!,
+    "7".unicodeScalars.first!,
+    "8".unicodeScalars.first!,
+    "9".unicodeScalars.first!,
+    "a".unicodeScalars.first!,
+    "b".unicodeScalars.first!,
+    "c".unicodeScalars.first!,
+    "d".unicodeScalars.first!,
+    "e".unicodeScalars.first!,
+    "f".unicodeScalars.first!
 ]
 

--- a/Source/JSONCore.swift
+++ b/Source/JSONCore.swift
@@ -11,327 +11,315 @@
 
 // MARK: Public API
 
-/// The specific type of Swift dictionary that represents valid JSON objects
-public typealias JSONObject = [String : JSONValue]
-
-// MARK: - JSON Values
-/// Numbers from JSON Core are wrapped in this enum to express its two possible
-/// storage types.
-public enum JSONNumberType {
-    /// Numbers in JSON that can be represented as whole numbers are stored as an `Int64`.
-    case JSONIntegral(Int64)
-    /// Numbers in JSON that have decimals or exponents are stored as `Double`.
-    case JSONFractional(Double)
-}
-
-/// Any value that can be expressed in JSON has a representation in `JSONValue`.
-public enum JSONValue {
-    /// Representation of JSON's number type.
-    case JSONNumber(JSONNumberType)
-    /// Representation of a `null` from JSON.
-    case JSONNull
-    /// Representation of strings from JSON.
-    case JSONString(String)
-    /// Representation of a JSON object, which is a Dictionary with `String` keys and `JSONValue` values.
-    case JSONObject([String:JSONValue])
-    /// Representation of `true` and `false` from JSON.
-    case JSONBool(Bool)
-    /// Representation of a JSON array, which is an array of `JSONValue`s.
-    case JSONArray([JSONValue])
-    
-    /// Returns this enum's associated String value if it is one, `nil` otherwise.
-    public var string: String? {
-        get {
-            switch self {
-            case .JSONString(let s):
-                return s
-            default:
-                return nil
-            }
-        }
-    }
-    
-    /// Returns this enum's associated Dictionary value if it is one, `nil` otherwise.
-    public var object: [String : JSONValue]? {
-        get {
-            switch self {
-            case .JSONObject(let o):
-                return o
-            default:
-                return nil
-            }
-        }
-    }
-    
-    /// Returns this enum's associated Bool value if it is one, `nil` otherwise.
-    public var bool: Bool? {
-        get {
-            switch self {
-            case .JSONBool(let b):
-                return b
-            default:
-                return nil
-            }
-        }
-    }
-    
-    /// Returns this enum's associated Array value if it is one, `nil` otherwise.
-    public var array: [JSONValue]? {
-        get {
-            switch self {
-            case .JSONArray(let a):
-                return a
-            default:
-                return nil
-            }
-        }
-    }
-    
-    /// Returns this enum's associated Int64 value if it is one, `nil` otherwise.
-    public var int: Int64? {
-        get {
-            switch self {
-            case .JSONNumber(let num):
-                switch num {
-                case .JSONIntegral(let i):
-                    return i
-                default:
-                    return nil
-                }
-            default:
-                return nil
-            }
-        }
-    }
-    
-    /// Returns this enum's associated Double value if it is one, `nil` otherwise.
-    public var double: Double? {
-        get {
-            switch self {
-            case .JSONNumber(let num):
-                switch num {
-                case .JSONFractional(let f):
-                    return f
-                default:
-                    return nil
-                }
-            default:
-                return nil
-            }
-        }
-    }
-    
-    /// Treat this JSONValue as a JSONObject and attempt to get or set its
-    /// associated Dictionary values.
-    public subscript(key: String) -> JSONValue? {
-        get {
-            if let object = self.object {
-                return object[key]
-            } else {
-                return nil
-            }
-        }
-        
-        set {
-            if let object = self.object {
-                var newObject = object
-                newObject[key] = newValue
-                self = JSONValue.JSONObject(newObject)
-            }
-        }
-    }
-    
-    /// Treat this JSONValue as a JSONArray and attempt to get or set its
-    /// associated Array values.
-    public subscript(index: Int) -> JSONValue? {
-        get {
-            if let array = self.array {
-                // TODO: Should I just let this crash, like Array does?
-                if index >= 0 && index < array.count {
-                    return array[index]
-                }
-            }
-            return nil
-        }
-        
-        set {
-            if let array = self.array, value = newValue {
-                var newArray = array
-                newArray[index] = value
-                self = JSONValue.JSONArray(newArray)
-            }
-        }
-    }
-}
-
-extension JSONNumberType : Equatable {}
-
-public func ==(lhs: JSONNumberType, rhs: JSONNumberType) -> Bool {
-    switch (lhs, rhs) {
-    case (let .JSONIntegral(l), let .JSONIntegral(r)):
-        return l == r
-    case (let .JSONFractional(l), let .JSONFractional(r)):
-        return l == r
-    default:
-        return false
-    }
-}
-
-extension JSONValue: Equatable {}
-
-public func ==(lhs: JSONValue, rhs: JSONValue) -> Bool {
-    switch (lhs, rhs) {
-    case (let .JSONNumber(lnum), let .JSONNumber(rnum)):
-        return lnum == rnum
-    case (.JSONNull, .JSONNull):
-        return true
-    case (let .JSONString(l), let .JSONString(r)):
-        return l == r
-    case (let .JSONObject(l), let .JSONObject(r)):
-        return l == r
-    case (let .JSONBool(l), let .JSONBool(r)):
-        return l == r
-    case (let .JSONArray(l), let .JSONArray(r)):
-        return l == r
-    default:
-        return false
-    }
-}
-
-extension JSONValue: IntegerLiteralConvertible {
-    public init(integerLiteral value: IntegerLiteralType) {
-        let val = Int64(value)
-        self = JSONValue.JSONNumber(.JSONIntegral(val))
-    }
-}
-
-extension JSONValue: FloatLiteralConvertible {
-    public init(floatLiteral value: FloatLiteralType) {
-        let val = Double(value)
-        self = JSONValue.JSONNumber(.JSONFractional(val))
-    }
-}
-
-extension JSONValue : StringLiteralConvertible {
-    public init(stringLiteral value: String) {
-        self = JSONValue.JSONString(value)
-    }
-    
-    public init(extendedGraphemeClusterLiteral value: String) {
-        self = JSONValue.JSONString(value)
-    }
-    
-    public init(unicodeScalarLiteral value: String) {
-        self = JSONValue.JSONString(value)
-    }
-}
-
-extension JSONValue : ArrayLiteralConvertible {
-    public init(arrayLiteral elements: JSONValue...) {
-        self = JSONValue.JSONArray(elements)
-    }
-}
-
-extension JSONValue : DictionaryLiteralConvertible {
-    public init(dictionaryLiteral elements: (String, JSONValue)...) {
-        var dict = [String : JSONValue]()
-        for (k, v) in elements {
-            dict[k] = v
-        }
-        
-        self = JSONValue.JSONObject(dict)
-    }
-}
-
-extension JSONValue : NilLiteralConvertible {
-    public init(nilLiteral: ()) {
-        self = JSONValue.JSONNull
-    }
-}
-
-extension JSONValue: BooleanLiteralConvertible {
-    public init(booleanLiteral value: Bool) {
-        self = JSONValue.JSONBool(value)
-    }
-}
-
-// MARK: - Errors
-
-/// Errors raised while parsing JSON data.
-public enum JSONParseError: ErrorType {
-    /// Some unknown error, usually indicates something not yet implemented.
-    case Unknown
-    /// Input data was either empty or contained only whitespace.
-    case EmptyInput
-    /// Some character that violates the strict JSON grammar was found.
-    case UnexpectedCharacter(lineNumber: UInt, characterNumber: UInt)
-    /// A JSON string was opened but never closed.
-    case UnterminatedString
-    /// Any unicode parsing errors will result in this error. Currently unused.
-    case InvalidUnicode
-    /// A keyword, like `null`, `true`, or `false` was expected but something else was in the input.
-    case UnexpectedKeyword(lineNumber: UInt, characterNumber: UInt)
-    /// Encountered a JSON number that couldn't be losslessly stored in a `Double` or `Int64`.
-    /// Usually the number is too large or too small.
-    case InvalidNumber(lineNumber: UInt, characterNumber: UInt)
-    /// End of file reached, not always an actual error.
-    case EndOfFile
-}
-
 /// Errors raised while serializing to a JSON string
 public enum JSONSerializeError: ErrorType {
-    /// Some unknown error, usually indicates something not yet implemented.
-    case Unknown
-    /// A number not supported by the JSON spec was encounterd, like infinity or NaN.
-    case InvalidNumber
+	/// Some unknown error, usually indicates something not yet implemented.
+	case Unknown
+	/// A number not supported by the JSON spec was encounterd, like infinity or NaN.
+	case InvalidNumber
 }
 
-extension JSONParseError: CustomStringConvertible {
-    /// Returns a `String` version of the error which can be logged.
-    /// Not currently localized.
-    public var description: String {
-        switch self {
-        case .Unknown:
-            return "Unknown error"
-        case .EmptyInput:
-            return "Empty input"
-        case .UnexpectedCharacter(let lineNumber, let charNum):
-            return "Unexpected character at \(lineNumber):\(charNum)"
-        case .UnterminatedString:
-            return "Unterminated string"
-        case .InvalidUnicode:
-            return "Invalid unicode"
-        case .UnexpectedKeyword(let lineNumber, let characterNumber):
-            return "Unexpected keyword at \(lineNumber):\(characterNumber)"
-        case .EndOfFile:
-            return "Unexpected end of file"
-        case .InvalidNumber:
-            return "Invalid number"
-        }
-    }
+/// Allows for the Int representation to be switched quickly
+/// Will maybe be non conformant to the JSON spec on 32bit machines
+/// Swift 3 will bring #if os(32bit) I think, that will be an approach to fix this.
+public typealias JSONInteger = Int
+
+/// Any value that can be expressed in JSON has a representation in `JSON`.
+public indirect enum JSON {
+	case object([String: JSON])
+	case array([JSON])
+	
+	case null
+	case bool(Bool)
+	case string(String)
+	case integer(JSONInteger)
+	case double(Double)
+	
+		/**
+	Turns a nested graph of `JSON`s into a Swift `String`. This produces JSON data that
+	strictly conforms to [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). 
+	TODO: It can optionally pretty-print the output for debugging, but this comes with a non-negligible performance cost.
+	*/
+	public func jsonString() throws -> String {
+		switch self {
+		case .array(let a):
+			var str = ""
+			for (i, v) in a.enumerate() {
+				str.appendContentsOf(try v.jsonString())
+				guard i != a.endIndex.predecessor() else { break }
+				str.appendContentsOf(",")
+			}
+			return "[" + str + "]"
+			
+		case .object(let o):
+			var str = ""
+			for (i, pair) in o.enumerate() {
+				let (key, value) = pair
+				let valueJSONString = try value.jsonString()
+				let keyPair = ["\"", key, "\":", valueJSONString].joinWithSeparator("")
+				str.appendContentsOf(keyPair)
+				guard i.successor() != o.count else { break }
+				str.appendContentsOf(",")
+			}
+			return "{" + str + "}"
+			
+		case .string(let s):
+			var output = ""
+			output.append(quotationMark)
+			var generator = s.unicodeScalars.generate()
+			while let scalar = generator.next() {
+				switch scalar.value {
+				case solidus.value:
+					fallthrough
+				case 0x0000...0x001F:
+					output.append(reverseSolidus)
+					switch scalar {
+					case tabCharacter:
+						output.appendContentsOf("t")
+					case carriageReturn:
+						output.appendContentsOf("r")
+					case lineFeed:
+						output.appendContentsOf("n")
+					case quotationMark:
+						output.append(quotationMark)
+					case backspace:
+						output.appendContentsOf("b")
+					case solidus:
+						output.append(solidus)
+					default:
+						output.appendContentsOf("u")
+						output.append(hexScalars[(Int(scalar.value) & 0xF000) >> 12])
+						output.append(hexScalars[(Int(scalar.value) & 0x0F00) >> 8])
+						output.append(hexScalars[(Int(scalar.value) & 0x00F0) >> 4])
+						output.append(hexScalars[(Int(scalar.value) & 0x000F) >> 0])
+					}
+				default:
+					output.append(scalar)
+				}
+			}
+			output.append(quotationMark)
+			return output
+			
+		case .null: return "null"
+		case .bool(let b): return b.description
+		case .integer(let i): return i.description
+		case .double(let f):
+			guard f.isFinite else {
+				throw JSONSerializeError.InvalidNumber
+			}
+			return f.description
+		}
+	}
+	
+	/// Returns this enum's associated Array value if it is one, `nil` otherwise.
+	public var array: [JSON]? {
+		guard case .array(let a) = self else { return nil }
+		return a
+	}
+	
+	/// Returns this enum's associated Dictionary value if it is one, `nil` otherwise.
+	public var object: [String: JSON]? {
+		guard case .object(let o) = self else { return nil }
+		return o
+	}
+	
+	/// Returns this enum's associated String value if it is one, `nil` otherwise.
+	public var string: String? {
+		guard case .string(let s) = self else { return nil }
+		return s
+	}
+	
+	/// Returns this enum's associated `JSONInteger` value if it is one, `nil` otherwise.
+	public var int: JSONInteger? {
+		guard case .integer(let i) = self else { return nil }
+		return i
+	}
+	
+	/// Returns this enum's associated Bool value if it is one, `nil` otherwise.
+	public var bool: Bool? {
+		guard case .bool(let b) = self else { return nil }
+		return b
+	}
+	
+	/// Returns this enum's associated Double value if it is one, `nil` otherwise.
+	public var double: Double? {
+		guard case .double(let d) = self else { return nil }
+		return d
+	}
 }
 
-extension JSONParseError: Equatable {}
+extension JSON: Equatable {}
 
-public func ==(lhs: JSONParseError, rhs: JSONParseError) -> Bool {
-    switch (lhs, rhs) {
-    case (.Unknown, .Unknown):
-        return true
-    case (.EmptyInput, .EmptyInput):
-        return true
-    case (let .UnexpectedCharacter(ll, lc), let .UnexpectedCharacter(rl, rc)):
-        return ll == rl && lc == rc
-    case (.UnterminatedString, .UnterminatedString):
-        return true
-    case (.InvalidUnicode, .InvalidUnicode):
-        return true
-    case (let .UnexpectedKeyword(ll, lc), let .UnexpectedKeyword(rl, rc)):
-        return ll == rl && lc == rc
-    case (.EndOfFile, .EndOfFile):
-        return true
-    default:
-        return false
-    }
+public func ==(lhs: JSON, rhs: JSON) -> Bool {
+	switch (lhs, rhs) {
+	case (.null, .null): return true
+	case (.bool(let l), .bool(let r)): return l == r
+	case (.array(let l), .array(let r)): return l == r
+	case (.string(let l), .string(let r)): return l == r
+	case (.object(let l), .object(let r)): return l == r
+	case (.integer(let l), .integer(let r)): return l == r
+	case (.double(let l), .double(let r)): return l == r
+		
+	default: return false
+	}
+}
+
+extension JSON: IntegerLiteralConvertible {
+	public init(integerLiteral value: IntegerLiteralType) {
+		let val = JSONInteger(value)
+		self = .integer(val)
+	}
+}
+
+extension JSON: FloatLiteralConvertible {
+	public init(floatLiteral value: FloatLiteralType) {
+		let val = Double(value)
+		self = .double(val)
+	}
+}
+
+extension JSON : StringLiteralConvertible {
+	public init(stringLiteral value: String) {
+		self = .string(value)
+	}
+	
+	public init(extendedGraphemeClusterLiteral value: String) {
+		self = .string(value)
+	}
+	
+	public init(unicodeScalarLiteral value: String) {
+		self = .string(value)
+	}
+}
+
+extension JSON : ArrayLiteralConvertible {
+	public init(arrayLiteral elements: JSON...) {
+		self = .array(elements)
+	}
+}
+
+extension JSON : DictionaryLiteralConvertible {
+	public init(dictionaryLiteral elements: (String, JSON)...) {
+		var dict: [String: JSON] = [:]
+		for (k, v) in elements {
+			dict[k] = v
+		}
+		
+		self = .object(dict)
+	}
+}
+
+extension JSON : NilLiteralConvertible {
+	public init(nilLiteral: ()) {
+		self = .null
+	}
+}
+
+extension JSON: BooleanLiteralConvertible {
+	public init(booleanLiteral value: Bool) {
+		self = .bool(value)
+	}
+}
+
+extension JSON {
+	init(string: String) throws {
+		self = .null
+	}
+}
+
+// MARK:- JSON Accessors
+
+extension JSON {
+	/// Treat this JSON as a JSON object and attempt to get or set its
+	/// associated Dictionary values.
+	public subscript(key: String) -> JSON? {
+		get {
+			guard case .object(let o) = self else { return nil }
+			return o[key]
+		}
+		
+		set {
+			guard case .object(var o) = self else { return }
+			o[key] = newValue
+			self = .object(o)
+		}
+	}
+	
+	/// Treat this JSON as a JSON array and attempt to get or set its
+	/// associated Array values.
+	/// This will do nothing if you attempt to set outside of bounds.
+	public subscript(index: Int) -> JSON? {
+		get {
+			guard case .array(let a) = self where a.indices ~= index else { return nil }
+			return a[index]
+		}
+		
+		set {
+			guard case .array(var a) = self where a.indices ~= index else { return }
+			switch newValue {
+			case .Some(let newValue):
+				a[index] = newValue
+				
+			case .None:
+				a.removeAtIndex(index)
+			}
+			self = .array(a)
+		}
+	}
+}
+
+/// WARNING: Internal type. Used to constrain an extension on Optional
+/// to be sudo non Generic. 
+/// *DO NOT USE* outside of JSONCore
+public protocol _JSONType {}
+extension JSON: _JSONType {}
+
+// TODO: Support set through these subscripts
+extension Optional where Wrapped: _JSONType {
+	/// Treat this Optional<_JSONType> as a JSON object and attempt to get its
+	/// associated Dictionary values.
+	/// Will return `nil` in the following cases:
+	/// - The JSON is not an object
+	/// - A value for the key is not found on the object
+	/// - The `Wrapped.type` != `JSON.type`
+	public subscript(key: String) -> JSON? {
+		// TODO(ethan): find a better way, should we fatalError() if it isn't `JSON`
+		// Would be best if we could constrain extensions to be Non-Generic. Swift3?
+		guard let o = (self as? JSON)?.object else { return nil }
+		return o[key]
+	}
+	
+	/// Treat this Optional<_JSONType> as a JSON array and attempt to get its
+	/// associated Array values.
+	/// Will return `nil` in the following cases:
+	/// - The JSON is not an array
+	/// - The index is outside of the array bounds
+	/// - The `Wrapped.type` != `JSON.type`
+	public subscript(index: Int) -> JSON? {
+		guard let a = (self as? JSON)?.array where a.indices ~= index else { return nil }
+		return a[index]
+	}
+}
+
+// MARK:- Parser
+public enum JSONParseError: ErrorType {
+	/// Some unknown error, usually indicates something not yet implemented.
+	case Unknown
+	/// Input data was either empty or contained only whitespace.
+	case EmptyInput
+	/// Some character that violates the strict JSON grammar was found.
+	case UnexpectedCharacter(lineNumber: UInt, characterNumber: UInt)
+	/// A JSON string was opened but never closed.
+	case UnterminatedString
+	/// Any unicode parsing errors will result in this error. Currently unused.
+	case InvalidUnicode
+	/// A keyword, like `null`, `true`, or `false` was expected but something else was in the input.
+	case UnexpectedKeyword(lineNumber: UInt, characterNumber: UInt)
+	/// Encountered a JSON number that couldn't be losslessly stored in a `Double` or `Int64`.
+	/// Usually the number is too large or too small.
+	case InvalidNumber(lineNumber: UInt, characterNumber: UInt)
+	/// End of file reached, not always an actual error.
+	case EndOfFile
 }
 
 // MARK:- Parser
@@ -340,714 +328,502 @@ public func ==(lhs: JSONParseError, rhs: JSONParseError) -> Bool {
 // https://github.com/nextive/NextiveJson
 
 /**
- Turns a String represented as a collection of Unicode scalars into a nested graph
- of `JSONValue`s. This is a strict parser implementing [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
- Being strict, it doesn't support common JSON extensions such as comments.
+Turns a String represented as a collection of Unicode scalars into a nested graph
+of `JSON`s. This is a strict parser implementing [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+Being strict, it doesn't support common JSON extensions such as comments.
 */
 public class JSONParser {
-    /**
-     A shortcut for creating a `JSONParser` and having it parse the given data.
-     This is a blocking operation, and will block the calling thread until parsing
-     finishes or throws an error.
-     - Parameter data: The Unicode scalars representing the input JSON data.
-     - Returns: The root `JSONValue` node from the input data.
-     - Throws: A `JSONParseError` if something failed during parsing.
-    */
-    public class func parseData(data: String.UnicodeScalarView) throws -> JSONValue {
-        let parser = JSONParser(data: data)
-        return try parser.parse()
-    }
-    
-    /**
-     A shortcut for creating a `JSONParser` and having it parse the given `String`.
-     This is a blocking operation, and will block the calling thread until parsing
-     finishes or throws an error.
-     - Parameter string: The `String` of the input JSON.
-     - Returns: The root `JSONValue` node from the input data.
-     - Throws: A `JSONParseError` if something failed during parsing.
-     */
-    public class func parseString(string: String) throws -> JSONValue {
-        let parser = JSONParser(data: string.unicodeScalars)
-        return try parser.parse()
-    }
-
-    /**
-     Designated initializer for `JSONParser`, which requires an input Unicode scalar
-     collection.
-     - Parameter data: The Unicode scalars representing the input JSON data.
-     */
-    public init(data: String.UnicodeScalarView) {
-        generator = data.generate()
-        self.data = data
-    }
-    
-    /**
-     Starts parsing the data. This is a blocking operation, and will block the 
-     calling thread until parsing finishes or throws an error.
-     - Returns: The root `JSONValue` node from the input data.
-     - Throws: A `JSONParseError` if something failed during parsing.
-    */
-    public func parse() throws -> JSONValue {
-        do {
-            try nextScalar()
-            let value = try nextValue()
-            do {
-                try nextScalar()
-                let v = scalar.value
-                if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-                    // Skip to EOF or the next token
-                    try skipToNextToken()
-                    // If we get this far some token was found ...
-                    throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-                } else {
-                    // There's some weird character at the end of the file...
-                    throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-                }
-            } catch JSONParseError.EndOfFile {
-                return value
-            }
-        } catch JSONParseError.EndOfFile {
-            throw JSONParseError.EmptyInput
-        }
-    }
-    
-    // MARK: - Internals: Properties
-    
-    var generator: String.UnicodeScalarView.Generator
-    let data: String.UnicodeScalarView
-    var scalar: UnicodeScalar!
-    var lineNumber: UInt = 0
-    var charNumber: UInt = 0
-    
-    var crlfHack = false
-    
-}
-
-// MARK:- Serializer
-
-/**
-Turns a nested graph of `JSONValue`s into a Swift `String`. This produces JSON data that
-strictly conforms to [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). It can optionally pretty-print the output for debugging, but this comes with a non-negligible performance cost.
-*/
-
-// TODO: Implement the pretty printer from SDJSONPrettyPrint. I've already written a
-// JSON serializer that produces decent output before so I should really reuse its
-// logic.
-public class JSONSerializer {
-    
-    /// What line endings should the pretty printer use
-    public enum LineEndings: String {
-        /// Unix (i.e Linux, Darwin) line endings: line feed
-        case Unix = "\n"
-        /// Windows line endings: carriage return + line feed
-        case Windows = "\r\n"
-    }
-    /// Whether this serializer will pretty print output or not.
-    public let prettyPrint: Bool
-    
-    /// What line endings should the pretty printer use
-    public let lineEndings: LineEndings
-    
-    /**
-     Designated initializer for `JSONSerializer`, which requires an input `JSONValue`.
-     - Parameter value: The `JSONValue` to convert to a `String`.
-     - Parameter prettyPrint: Whether to print superfluous newlines and spaces to
-     make the output easier to read. Has a non-negligible performance cost. Defaults
-     to `false`.
-     */
-    public init(value: JSONValue, prettyPrint: Bool = false, lineEndings: LineEndings = .Unix) {
-        self.prettyPrint = prettyPrint
-        self.rootValue = value
-        self.lineEndings = lineEndings
-    }
-    
-    /**
-     Shortcut for creating a `JSONSerializer` and having it serialize the given
-     value.
-     - Parameter value: The `JSONValue` to convert to a `String`.
-     - Parameter prettyPrint: Whether to print superfluous newlines and spaces to
-     make the output easier to read. Has a non-negligible performance cost. Defaults
-     to `false`.
-     - Returns: The serialized value as a `String`.
-     - Throws: A `JSONSerializeError` if something failed during serialization.
-     */
-    public class func serializeValue(value: JSONValue, prettyPrint: Bool = false) throws -> String {
-        let serializer = JSONSerializer(value: value, prettyPrint: prettyPrint)
-        return try serializer.serialize()
-    }
-    
-    /**
-     Serializes the value passed during initialization.
-     - Returns: The serialized value as a `String`.
-     - Throws: A `JSONSerializeError` if something failed during serialization.
-     */
-    public func serialize() throws -> String {
-        try serializeValue(rootValue)
-        return output
-    }
-    
-    // MARK: Internals: Properties
-    let rootValue: JSONValue
-    var output: String = ""
+	/**
+	A shortcut for creating a `JSONParser` and having it parse the given data.
+	This is a blocking operation, and will block the calling thread until parsing
+	finishes or throws an error.
+	- Parameter data: The Unicode scalars representing the input JSON data.
+	- Returns: The root `JSON` node from the input data.
+	- Throws: A `JSONParseError` if something failed during parsing.
+	*/
+	public class func parse(data: String.UnicodeScalarView) throws -> JSON {
+		let parser = JSONParser(data: data)
+		return try parser.parse()
+	}
+	
+	/**
+	A shortcut for creating a `JSONParser` and having it parse the given `String`.
+	This is a blocking operation, and will block the calling thread until parsing
+	finishes or throws an error.
+	- Parameter string: The `String` of the input JSON.
+	- Returns: The root `JSON` node from the input data.
+	- Throws: A `JSONParseError` if something failed during parsing.
+	*/
+	public class func parse(string: String) throws -> JSON {
+		let parser = JSONParser(data: string.unicodeScalars)
+		return try parser.parse()
+	}
+	
+	/**
+	Designated initializer for `JSONParser`, which requires an input Unicode scalar
+	collection.
+	- Parameter data: The Unicode scalars representing the input JSON data.
+	*/
+	public init(data: String.UnicodeScalarView) {
+		generator = data.generate()
+		self.data = data
+	}
+	
+	/**
+	Starts parsing the data. This is a blocking operation, and will block the
+	calling thread until parsing finishes or throws an error.
+	- Returns: The root `JSON` node from the input data.
+	- Throws: A `JSONParseError` if something failed during parsing.
+	*/
+	public func parse() throws -> JSON {
+		do {
+			try nextScalar()
+			let value = try nextValue()
+			do {
+				try nextScalar()
+				let v = scalar.value
+				if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+					// Skip to EOF or the next token
+					try skipToNextToken()
+					// If we get this far some token was found ...
+					throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+				} else {
+					// There's some weird character at the end of the file...
+					throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+				}
+			} catch JSONParseError.EndOfFile {
+				return value
+			}
+		} catch JSONParseError.EndOfFile {
+			throw JSONParseError.EmptyInput
+		}
+	}
+	
+	// MARK: - Internals: Properties
+	
+	var generator: String.UnicodeScalarView.Generator
+	let data: String.UnicodeScalarView
+	var scalar: UnicodeScalar!
+	var lineNumber: UInt = 0
+	var charNumber: UInt = 0
+	
+	var crlfHack = false
+	
 }
 
 // MARK: JSONParser Internals
 extension JSONParser {
-    // MARK: - Enumerating the scalar collection
-    func nextScalar() throws {
-        if let sc = generator.next() {
-            scalar = sc
-            charNumber = charNumber + 1
-            if crlfHack == true && sc != lineFeed {
-                crlfHack = false
-            }
-        } else {
-            throw JSONParseError.EndOfFile
-        }
-    }
-    
-    func skipToNextToken() throws {
-        var v = scalar.value
-        if v != 0x0009 && v != 0x000A && v != 0x000D && v != 0x0020 {
-            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-        }
-        
-        while v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-            if scalar == carriageReturn || scalar == lineFeed {
-                if crlfHack == true && scalar == lineFeed {
-                    crlfHack = false
-                    charNumber = 0
-                } else {
-                    if (scalar == carriageReturn) {
-                        crlfHack = true
-                    }
-                    lineNumber = lineNumber + 1
-                    charNumber = 0
-                }
-            }
-            try nextScalar()
-            v = scalar.value
-        }
-    }
-    
-    func nextScalars(count: UInt) throws -> [UnicodeScalar] {
-        var values = [UnicodeScalar]()
-        values.reserveCapacity(Int(count))
-        for _ in 0..<count {
-            try nextScalar()
-            values.append(scalar)
-        }
-        return values
-    }
-    
-    // MARK: - Parse loop
-    func nextValue() throws -> JSONValue {
-        let v = scalar.value
-        if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-            try skipToNextToken()
-        }
-        switch scalar {
-        case leftCurlyBracket:
-            return try nextObject()
-        case leftSquareBracket:
-            return try nextArray()
-        case quotationMark:
-            return try nextString()
-        case trueToken[0], falseToken[0]:
-            return try nextBool()
-        case nullToken[0]:
-            return try nextNull()
-        case "0".unicodeScalars.first!..."9".unicodeScalars.first!,negativeScalar,decimalScalar:
-            return try nextNumber()
-        default:
-            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-        }
-    }
-    
-    // MARK: - Parse a specific, expected type
-    func nextObject() throws -> JSONValue {
-        if scalar != leftCurlyBracket {
-            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-        }
-        var dictBuilder = [String : JSONValue]()
-        try nextScalar()
-        if scalar == rightCurlyBracket {
-            // Empty object
-            return JSONValue.JSONObject(dictBuilder)
-        }
-        outerLoop: repeat {
-            var v = scalar.value
-            if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-                try skipToNextToken()
-            }
-            let jsonString = try nextString()
-            try nextScalar() // Skip the quotation character
-            v = scalar.value
-            if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-                try skipToNextToken()
-            }
-            if scalar != colon {
-                throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-            }
-            try nextScalar() // Skip the ':'
-            let value = try nextValue()
-            switch value {
-                // Skip the closing character for all values except number, which doesn't have one
-            case .JSONNumber:
-                break
-            default:
-                try nextScalar()
-            }
-            v = scalar.value
-            if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-                try skipToNextToken()
-            }
-            let key = jsonString.string! // We're pretty confident it's a string since we called nextString() above
-            dictBuilder[key] = value
-            switch scalar {
-            case rightCurlyBracket:
-                break outerLoop
-            case comma:
-                try nextScalar()
-            default:
-                throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-            }
-            
-        } while true
-        return JSONValue.JSONObject(dictBuilder)
-    }
-    
-    func nextArray() throws -> JSONValue {
-        if scalar != leftSquareBracket {
-            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-        }
-        var arrBuilder = [JSONValue]()
-        try nextScalar()
-        if scalar == rightSquareBracket {
-            // Empty array
-            return JSONValue.JSONArray(arrBuilder)
-        }
-        outerLoop: repeat {
-            let value = try nextValue()
-            arrBuilder.append(value)
-            switch value {
-                // Skip the closing character for all values except number, which doesn't have one
-            case .JSONNumber:
-                break
-            default:
-                try nextScalar()
-            }
-            let v = scalar.value
-            if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
-                try skipToNextToken()
-            }
-            switch scalar {
-            case rightSquareBracket:
-                break outerLoop
-            case comma:
-                try nextScalar()
-            default:
-                throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-            }
-        } while true
-        
-        return JSONValue.JSONArray(arrBuilder)
-    }
-    
-    func nextString() throws -> JSONValue {
-        if scalar != quotationMark {
-            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-        }
-        try nextScalar() // Skip pas the quotation character
-        var strBuilder = ""
-        var escaping = false
-        outerLoop: repeat {
-            // First we should deal with the escape character and the terminating quote
-            switch scalar {
-            case reverseSolidus:
-                // Escape character
-                if escaping {
-                    // Escaping the escape char
-                    strBuilder.append(reverseSolidus)
-                }
-                escaping = !escaping
-                try nextScalar()
-            case quotationMark:
-                if escaping {
-                    strBuilder.append(quotationMark)
-                    escaping = false
-                    try nextScalar()
-                } else {
-                    break outerLoop
-                }
-            default:
-                // Now the rest
-                if escaping {
-                    // Handle all the different escape characters
-                    if let s = escapeMap[scalar] {
-                        strBuilder.append(s)
-                        try nextScalar()
-                    } else if scalar == "u".unicodeScalars.first! {
-                        let escapedUnicodeValue = try nextUnicodeEscape()
-                        strBuilder.append(UnicodeScalar(escapedUnicodeValue))
-                        try nextScalar()
-                    }
-                    escaping = false
-                } else {
-                    // Simple append
-                    strBuilder.append(scalar)
-                    try nextScalar()
-                }
-            }
-        } while true
-        return JSONValue.JSONString(strBuilder)
-    }
-    
-    func nextUnicodeEscape() throws -> UInt32 {
-        if scalar != "u".unicodeScalars.first! {
-            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-        }
-        var readScalar = UInt32(0)
-        for _ in 0...3 {
-            readScalar = readScalar * 16
-            try nextScalar()
-            if ("0".unicodeScalars.first!..."9".unicodeScalars.first!).contains(scalar) {
-                readScalar = readScalar + UInt32(scalar.value - "0".unicodeScalars.first!.value)
-            } else if ("a".unicodeScalars.first!..."f".unicodeScalars.first!).contains(scalar) {
-                let aScalarVal = "a".unicodeScalars.first!.value
-                let hexVal = scalar.value - aScalarVal
-                let hexScalarVal = hexVal + 10
-                readScalar = readScalar + hexScalarVal
-            } else if ("A".unicodeScalars.first!..."F".unicodeScalars.first!).contains(scalar) {
-                let aScalarVal = "A".unicodeScalars.first!.value
-                let hexVal = scalar.value - aScalarVal
-                let hexScalarVal = hexVal + 10
-                readScalar = readScalar + hexScalarVal
-            } else {
-                throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-            }
-        }
-        if readScalar >= 0xD800 && readScalar <= 0xDBFF {
-            // UTF-16 surrogate pair
-            // The next character MUST be the other half of the surrogate pair
-            // Otherwise it's a unicode error
-            do {
-                try nextScalar()
-                if scalar != reverseSolidus {
-                    throw JSONParseError.InvalidUnicode
-                }
-                try nextScalar()
-                let secondScalar = try nextUnicodeEscape()
-                if secondScalar < 0xDC00 || secondScalar > 0xDFFF {
-                    throw JSONParseError.InvalidUnicode
-                }
-                let actualScalar = (readScalar - 0xD800) * 0x400 + (secondScalar - 0xDC00) + 0x10000
-                return actualScalar
-            } catch JSONParseError.UnexpectedCharacter {
-                throw JSONParseError.InvalidUnicode
-            }
-        }
-        return readScalar
-    }
-    
-    func nextNumber() throws -> JSONValue {
-        var isNegative = false
-        var hasDecimal = false
-        var hasDigits = false
-        var hasExponent = false
-        var positiveExponent = false
-        var exponent = 0
-        var integer: UInt64 = 0
-        var decimal: Int64 = 0
-        var divisor: Double = 10
-        let lineNumAtStart = lineNumber
-        let charNumAtStart = charNumber
-        
-        do {
-            outerLoop: repeat {
-                switch scalar {
-                case "0".unicodeScalars.first!..."9".unicodeScalars.first!:
-                    hasDigits = true
-                    if hasDecimal {
-                        decimal *= 10
-                        decimal += Int64(scalar.value - zeroScalar.value)
-                        divisor *= 10
-                    } else {
-                        integer *= 10
-                        integer += UInt64(scalar.value - zeroScalar.value)
-                    }
-                    try nextScalar()
-                case negativeScalar:
-                    if hasDigits || hasDecimal || hasDigits || isNegative {
-                        throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-                    } else {
-                        isNegative = true
-                    }
-                    try nextScalar()
-                case decimalScalar:
-                    if hasDecimal {
-                        throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-                    } else {
-                        hasDecimal = true
-                    }
-                    try nextScalar()
-                case "e".unicodeScalars.first!,"E".unicodeScalars.first!:
-                    if hasExponent {
-                        throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-                    } else {
-                        hasExponent = true
-                    }
-                    try nextScalar()
-                    switch scalar {
-                    case "0".unicodeScalars.first!..."9".unicodeScalars.first!:
-                        positiveExponent = true
-                    case plusScalar:
-                        positiveExponent = true
-                        try nextScalar()
-                    case negativeScalar:
-                        positiveExponent = false
-                        try nextScalar()
-                    default:
-                        throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-                    }
-                    exponentLoop: repeat {
-                        if scalar.value >= zeroScalar.value && scalar.value <= "9".unicodeScalars.first!.value {
-                            exponent *= 10
-                            exponent += Int(scalar.value - zeroScalar.value)
-                            try nextScalar()
-                        } else {
-                            break exponentLoop
-                        }
-                    } while true
-                default:
-                    break outerLoop
-                }
-            } while true
-        } catch JSONParseError.EndOfFile {
-            // This is fine
-        }
-        
-        if !hasDigits {
-            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-        }
-        
-        let sign = isNegative ? -1 : 1
-        if hasDecimal || hasExponent {
-            divisor /= 10
-            var number = Double(sign) * (Double(integer) + (Double(decimal) / divisor))
-            if hasExponent {
-                if positiveExponent {
-                    for _ in 1...exponent {
-                        number *= Double(10)
-                    }
-                } else {
-                    for _ in 1...exponent {
-                        number /= Double(10)
-                    }
-                }
-            }
-            return JSONValue.JSONNumber(JSONNumberType.JSONFractional(number))
-        } else {
-            var number: Int64
-            if isNegative {
-                if integer > UInt64(Int64.max) + 1 {
-                    throw JSONParseError.InvalidNumber(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
-                } else if integer == UInt64(Int64.max) + 1 {
-                    number = Int64.min
-                } else {
-                    number = Int64(integer) * -1
-                }
-            } else {
-                if integer > UInt64(Int64.max) {
-                    throw JSONParseError.InvalidNumber(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
-                } else {
-                    number = Int64(integer)
-                }
-            }
-            return JSONValue.JSONNumber(JSONNumberType.JSONIntegral(number))
-        }
-    }
-    
-    func nextBool() throws -> JSONValue {
-        var expectedWord: [UnicodeScalar]
-        var expectedBool: Bool
-        let lineNumAtStart = lineNumber
-        let charNumAtStart = charNumber
-        if scalar == trueToken[0] {
-            expectedWord = trueToken
-            expectedBool = true
-        } else if scalar == falseToken[0] {
-            expectedWord = falseToken
-            expectedBool = false
-        } else {
-            throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
-        }
-        do {
-            let word = try [scalar] + nextScalars(UInt(expectedWord.count - 1))
-            if word != expectedWord {
-                throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
-            }
-        } catch JSONParseError.EndOfFile {
-            throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
-        }
-        return JSONValue.JSONBool(expectedBool)
-    }
-    
-    func nextNull() throws -> JSONValue {
-        let word = try [scalar] + nextScalars(3)
-        if word != nullToken {
-            throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumber, characterNumber: charNumber-4)
-        }
-        return JSONValue.JSONNull
-    }
+	// MARK: - Enumerating the scalar collection
+	func nextScalar() throws {
+		if let sc = generator.next() {
+			scalar = sc
+			charNumber = charNumber + 1
+			if crlfHack == true && sc != lineFeed {
+				crlfHack = false
+			}
+		} else {
+			throw JSONParseError.EndOfFile
+		}
+	}
+	
+	func skipToNextToken() throws {
+		var v = scalar.value
+		if v != 0x0009 && v != 0x000A && v != 0x000D && v != 0x0020 {
+			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+		}
+		
+		while v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+			if scalar == carriageReturn || scalar == lineFeed {
+				if crlfHack == true && scalar == lineFeed {
+					crlfHack = false
+					charNumber = 0
+				} else {
+					if (scalar == carriageReturn) {
+						crlfHack = true
+					}
+					lineNumber = lineNumber + 1
+					charNumber = 0
+				}
+			}
+			try nextScalar()
+			v = scalar.value
+		}
+	}
+	
+	func nextScalars(count: UInt) throws -> [UnicodeScalar] {
+		var values = [UnicodeScalar]()
+		values.reserveCapacity(Int(count))
+		for _ in 0..<count {
+			try nextScalar()
+			values.append(scalar)
+		}
+		return values
+	}
+	
+	// MARK: - Parse loop
+	func nextValue() throws -> JSON {
+		let v = scalar.value
+		if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+			try skipToNextToken()
+		}
+		switch scalar {
+		case leftCurlyBracket:
+			return try nextObject()
+		case leftSquareBracket:
+			return try nextArray()
+		case quotationMark:
+			return try nextString()
+		case trueToken[0], falseToken[0]:
+			return try nextBool()
+		case nullToken[0]:
+			return try nextNull()
+		case "0".unicodeScalars.first!..."9".unicodeScalars.first!,negativeScalar,decimalScalar:
+			return try nextNumber()
+		default:
+			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+		}
+	}
+	
+	// MARK: - Parse a specific, expected type
+	func nextObject() throws -> JSON {
+		if scalar != leftCurlyBracket {
+			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+		}
+		var dictBuilder = [String : JSON]()
+		try nextScalar()
+		if scalar == rightCurlyBracket {
+			// Empty object
+			return JSON.object(dictBuilder)
+		}
+		outerLoop: repeat {
+			var v = scalar.value
+			if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+				try skipToNextToken()
+			}
+			let string = try nextString()
+			try nextScalar() // Skip the quotation character
+			v = scalar.value
+			if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+				try skipToNextToken()
+			}
+			if scalar != colon {
+				throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+			}
+			try nextScalar() // Skip the ':'
+			let value = try nextValue()
+			switch value {
+			// Skip the closing character for all values except number, which doesn't have one
+			case .integer, .double:
+				break
+			default:
+				try nextScalar()
+			}
+			v = scalar.value
+			if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+				try skipToNextToken()
+			}
+			guard case .string(let key) = string else { throw JSONParseError.Unknown }
+			//let key = string.string! // We're pretty confident it's a string since we called nextString() above
+			dictBuilder[key] = value
+			switch scalar {
+			case rightCurlyBracket:
+				break outerLoop
+			case comma:
+				try nextScalar()
+			default:
+				throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+			}
+			
+		} while true
+		return JSON.object(dictBuilder)
+	}
+	
+	func nextArray() throws -> JSON {
+		if scalar != leftSquareBracket {
+			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+		}
+		var arrBuilder = [JSON]()
+		try nextScalar()
+		if scalar == rightSquareBracket {
+			// Empty array
+			return JSON.array(arrBuilder)
+		}
+		outerLoop: repeat {
+			let value = try nextValue()
+			arrBuilder.append(value)
+			switch value {
+			// Skip the closing character for all values except number, which doesn't have one
+			case .integer, .double:
+				break
+			default:
+				try nextScalar()
+			}
+			let v = scalar.value
+			if v == 0x0009 || v == 0x000A || v == 0x000D || v == 0x0020 {
+				try skipToNextToken()
+			}
+			switch scalar {
+			case rightSquareBracket:
+				break outerLoop
+			case comma:
+				try nextScalar()
+			default:
+				throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+			}
+		} while true
+		
+		return JSON.array(arrBuilder)
+	}
+	
+	func nextString() throws -> JSON {
+		if scalar != quotationMark {
+			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+		}
+		try nextScalar() // Skip pas the quotation character
+		var strBuilder = ""
+		var escaping = false
+		outerLoop: repeat {
+			// First we should deal with the escape character and the terminating quote
+			switch scalar {
+			case reverseSolidus:
+				// Escape character
+				if escaping {
+					// Escaping the escape char
+					strBuilder.append(reverseSolidus)
+				}
+				escaping = !escaping
+				try nextScalar()
+			case quotationMark:
+				if escaping {
+					strBuilder.append(quotationMark)
+					escaping = false
+					try nextScalar()
+				} else {
+					break outerLoop
+				}
+			default:
+				// Now the rest
+				if escaping {
+					// Handle all the different escape characters
+					if let s = escapeMap[scalar] {
+						strBuilder.append(s)
+						try nextScalar()
+					} else if scalar == "u".unicodeScalars.first! {
+						let escapedUnicodeValue = try nextUnicodeEscape()
+						strBuilder.append(UnicodeScalar(escapedUnicodeValue))
+						try nextScalar()
+					}
+					escaping = false
+				} else {
+					// Simple append
+					strBuilder.append(scalar)
+					try nextScalar()
+				}
+			}
+		} while true
+		return JSON.string(strBuilder)
+	}
+	
+	func nextUnicodeEscape() throws -> UInt32 {
+		if scalar != "u".unicodeScalars.first! {
+			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+		}
+		var readScalar = UInt32(0)
+		for _ in 0...3 {
+			readScalar = readScalar * 16
+			try nextScalar()
+			if ("0".unicodeScalars.first!..."9".unicodeScalars.first!).contains(scalar) {
+				readScalar = readScalar + UInt32(scalar.value - "0".unicodeScalars.first!.value)
+			} else if ("a".unicodeScalars.first!..."f".unicodeScalars.first!).contains(scalar) {
+				let aScalarVal = "a".unicodeScalars.first!.value
+				let hexVal = scalar.value - aScalarVal
+				let hexScalarVal = hexVal + 10
+				readScalar = readScalar + hexScalarVal
+			} else if ("A".unicodeScalars.first!..."F".unicodeScalars.first!).contains(scalar) {
+				let aScalarVal = "A".unicodeScalars.first!.value
+				let hexVal = scalar.value - aScalarVal
+				let hexScalarVal = hexVal + 10
+				readScalar = readScalar + hexScalarVal
+			} else {
+				throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+			}
+		}
+		if readScalar >= 0xD800 && readScalar <= 0xDBFF {
+			// UTF-16 surrogate pair
+			// The next character MUST be the other half of the surrogate pair
+			// Otherwise it's a unicode error
+			do {
+				try nextScalar()
+				if scalar != reverseSolidus {
+					throw JSONParseError.InvalidUnicode
+				}
+				try nextScalar()
+				let secondScalar = try nextUnicodeEscape()
+				if secondScalar < 0xDC00 || secondScalar > 0xDFFF {
+					throw JSONParseError.InvalidUnicode
+				}
+				let actualScalar = ((readScalar - 0xD800) * 0x400) + ((secondScalar - 0xDC00) + 0x10000)
+				return actualScalar
+			} catch JSONParseError.UnexpectedCharacter {
+				throw JSONParseError.InvalidUnicode
+			}
+		}
+		return readScalar
+	}
+	
+	func nextNumber() throws -> JSON {
+		var isNegative = false
+		var hasDecimal = false
+		var hasDigits = false
+		var hasExponent = false
+		var positiveExponent = false
+		var exponent = 0
+		var integer: UInt64 = 0
+		var decimal: Int64 = 0
+		var divisor: Double = 10
+		let lineNumAtStart = lineNumber
+		let charNumAtStart = charNumber
+		
+		do {
+			outerLoop: repeat {
+				switch scalar {
+				case "0".unicodeScalars.first!..."9".unicodeScalars.first!:
+					hasDigits = true
+					if hasDecimal {
+						decimal *= 10
+						decimal += Int64(scalar.value - zeroScalar.value)
+						divisor *= 10
+					} else {
+						integer *= 10
+						integer += UInt64(scalar.value - zeroScalar.value)
+					}
+					try nextScalar()
+				case negativeScalar:
+					if hasDigits || hasDecimal || hasDigits || isNegative {
+						throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+					} else {
+						isNegative = true
+					}
+					try nextScalar()
+				case decimalScalar:
+					if hasDecimal {
+						throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+					} else {
+						hasDecimal = true
+					}
+					try nextScalar()
+				case "e".unicodeScalars.first!,"E".unicodeScalars.first!:
+					if hasExponent {
+						throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+					} else {
+						hasExponent = true
+					}
+					try nextScalar()
+					switch scalar {
+					case "0".unicodeScalars.first!..."9".unicodeScalars.first!:
+						positiveExponent = true
+					case plusScalar:
+						positiveExponent = true
+						try nextScalar()
+					case negativeScalar:
+						positiveExponent = false
+						try nextScalar()
+					default:
+						throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+					}
+					exponentLoop: repeat {
+						if scalar.value >= zeroScalar.value && scalar.value <= "9".unicodeScalars.first!.value {
+							exponent *= 10
+							exponent += Int(scalar.value - zeroScalar.value)
+							try nextScalar()
+						} else {
+							break exponentLoop
+						}
+					} while true
+				default:
+					break outerLoop
+				}
+			} while true
+		} catch JSONParseError.EndOfFile {
+			// This is fine
+		}
+		
+		if !hasDigits {
+			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+		}
+		
+		let sign = isNegative ? -1 : 1
+		if hasDecimal || hasExponent {
+			divisor /= 10
+			var number = Double(sign) * (Double(integer) + (Double(decimal) / divisor))
+			if hasExponent {
+				if positiveExponent {
+					for _ in 1...exponent {
+						number *= Double(10)
+					}
+				} else {
+					for _ in 1...exponent {
+						number /= Double(10)
+					}
+				}
+			}
+			return JSON.double(number)
+		} else {
+			var number: Int64
+			if isNegative {
+				if integer > UInt64(Int64.max) + 1 {
+					throw JSONParseError.InvalidNumber(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
+				} else if integer == UInt64(Int64.max) + 1 {
+					number = Int64.min
+				} else {
+					number = Int64(integer) * -1
+				}
+			} else {
+				if integer > UInt64(Int64.max) {
+					throw JSONParseError.InvalidNumber(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
+				} else {
+					number = Int64(integer)
+				}
+			}
+			return JSON.integer(JSONInteger(number))
+		}
+	}
+	
+	func nextBool() throws -> JSON {
+		var expectedWord: [UnicodeScalar]
+		var expectedBool: Bool
+		let lineNumAtStart = lineNumber
+		let charNumAtStart = charNumber
+		if scalar == trueToken[0] {
+			expectedWord = trueToken
+			expectedBool = true
+		} else if scalar == falseToken[0] {
+			expectedWord = falseToken
+			expectedBool = false
+		} else {
+			throw JSONParseError.UnexpectedCharacter(lineNumber: lineNumber, characterNumber: charNumber)
+		}
+		do {
+			let word = try [scalar] + nextScalars(UInt(expectedWord.count - 1))
+			if word != expectedWord {
+				throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
+			}
+		} catch JSONParseError.EndOfFile {
+			throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumAtStart, characterNumber: charNumAtStart)
+		}
+		return JSON.bool(expectedBool)
+	}
+	
+	func nextNull() throws -> JSON {
+		let word = try [scalar] + nextScalars(3)
+		if word != nullToken {
+			throw JSONParseError.UnexpectedKeyword(lineNumber: lineNumber, characterNumber: charNumber-4)
+		}
+		return JSON.null
+	}
 }
 
-// MARK: JSONSerializer Internals
-extension JSONSerializer {
-    
-    func serializeValue(value: JSONValue, indentLevel: Int = 0) throws {
-        switch value {
-        case .JSONNumber(let nt):
-            switch nt {
-            case .JSONFractional(let f):
-                try serializeDouble(f)
-            case .JSONIntegral(let i):
-                serializeInt64(i)
-            }
-        case .JSONNull:
-            serializeNull()
-        case .JSONString(let s):
-            serializeString(s)
-        case .JSONObject(let obj):
-            try serializeObject(obj, indentLevel: indentLevel)
-        case .JSONBool(let b):
-            serializeBool(b)
-        case .JSONArray(let a):
-            try serializeArray(a, indentLevel: indentLevel)
-        }
-    }
-    
-    func serializeObject(obj: [String : JSONValue], indentLevel: Int = 0) throws {
-        output.append(leftCurlyBracket)
-        serializeNewline()
-        var i = 0
-        for (key, value) in obj {
-            serializeSpaces(indentLevel + 1)
-            serializeString(key)
-            output.append(colon)
-            if prettyPrint {
-                output.appendContentsOf(" ")
-            }
-            try serializeValue(value, indentLevel: indentLevel + 1)
-            i += 1
-            if i != obj.count {
-                output.append(comma)
-                
-            }
-            serializeNewline()
-        }
-        serializeSpaces(indentLevel)
-        output.append(rightCurlyBracket)
-    }
-    
-    func serializeArray(arr: [JSONValue], indentLevel: Int = 0) throws {
-        output.append(leftSquareBracket)
-        serializeNewline()
-        var i = 0
-        for val in arr {
-            serializeSpaces(indentLevel + 1)
-            try serializeValue(val, indentLevel: indentLevel + 1)
-            i += 1
-            if i != arr.count {
-                output.append(comma)
-            }
-            serializeNewline()
-        }
-        serializeSpaces(indentLevel)
-        output.append(rightSquareBracket)
-    }
-    
-    func serializeString(str: String) {
-        output.append(quotationMark)
-        var generator = str.unicodeScalars.generate()
-        while let scalar = generator.next() {
-            switch scalar.value {
-            case solidus.value:
-                fallthrough
-            case 0x0000...0x001F:
-                output.append(reverseSolidus)
-                switch scalar {
-                case tabCharacter:
-                    output.appendContentsOf("t")
-                case carriageReturn:
-                    output.appendContentsOf("r")
-                case lineFeed:
-                    output.appendContentsOf("n")
-                case quotationMark:
-                    output.append(quotationMark)
-                case backspace:
-                    output.appendContentsOf("b")
-                case solidus:
-                    output.append(solidus)
-                default:
-                    output.appendContentsOf("u")
-                    output.append(hexScalars[(Int(scalar.value) & 0xF000) >> 12])
-                    output.append(hexScalars[(Int(scalar.value) & 0x0F00) >> 8])
-                    output.append(hexScalars[(Int(scalar.value) & 0x00F0) >> 4])
-                    output.append(hexScalars[(Int(scalar.value) & 0x000F) >> 0])
-                }
-            default:
-                output.append(scalar)
-            }
-        }
-        output.append(quotationMark)
-    }
-    
-    func serializeDouble(f: Double) throws {
-        if f.isNaN || f.isInfinite {
-            throw JSONSerializeError.InvalidNumber
-        } else {
-            // TODO: Is CustomStringConvertible for number types affected by locale?
-            // TODO: Is CustomStringConvertible for Double fast?
-            output.appendContentsOf(f.description)
-        }
-    }
-    
-    func serializeInt64(i: Int64) {
-        // TODO: Is CustomStringConvertible for number types affected by locale?
-        output.appendContentsOf(i.description)
-    }
-    
-    func serializeBool(bool: Bool) {
-        switch bool {
-        case true:
-            output.appendContentsOf("true")
-        case false:
-            output.appendContentsOf("false")
-        }
-    }
-    
-    func serializeNull() {
-        output.appendContentsOf("null")
-    }
-    
-    @inline(__always)
-    private final func serializeNewline() {
-        if prettyPrint {
-            output.appendContentsOf(lineEndings.rawValue)
-        }
-    }
-    
-    @inline(__always)
-    private final func serializeSpaces(indentLevel: Int = 0) {
-        if prettyPrint {
-            for _ in 0..<indentLevel {
-                output.appendContentsOf("  ")
-            }
-        }
-    }
-}
-
+// MARK:- Unicode Scalars
 
 private let leftSquareBracket = UnicodeScalar(0x005b)
 private let leftCurlyBracket = UnicodeScalar(0x007b)
@@ -1075,29 +851,30 @@ private let falseToken = [UnicodeScalar]("false".unicodeScalars)
 private let nullToken = [UnicodeScalar]("null".unicodeScalars)
 
 private let escapeMap = [
-    "/".unicodeScalars.first!: solidus,
-    "b".unicodeScalars.first!: backspace,
-    "f".unicodeScalars.first!: formFeed,
-    "n".unicodeScalars.first!: lineFeed,
-    "r".unicodeScalars.first!: carriageReturn,
-    "t".unicodeScalars.first!: tabCharacter
+	"/".unicodeScalars.first!: solidus,
+	"b".unicodeScalars.first!: backspace,
+	"f".unicodeScalars.first!: formFeed,
+	"n".unicodeScalars.first!: lineFeed,
+	"r".unicodeScalars.first!: carriageReturn,
+	"t".unicodeScalars.first!: tabCharacter
 ]
 
 private let hexScalars = [
-    "0".unicodeScalars.first!,
-    "1".unicodeScalars.first!,
-    "2".unicodeScalars.first!,
-    "3".unicodeScalars.first!,
-    "4".unicodeScalars.first!,
-    "5".unicodeScalars.first!,
-    "6".unicodeScalars.first!,
-    "7".unicodeScalars.first!,
-    "8".unicodeScalars.first!,
-    "9".unicodeScalars.first!,
-    "a".unicodeScalars.first!,
-    "b".unicodeScalars.first!,
-    "c".unicodeScalars.first!,
-    "d".unicodeScalars.first!,
-    "e".unicodeScalars.first!,
-    "f".unicodeScalars.first!
+	"0".unicodeScalars.first!,
+	"1".unicodeScalars.first!,
+	"2".unicodeScalars.first!,
+	"3".unicodeScalars.first!,
+	"4".unicodeScalars.first!,
+	"5".unicodeScalars.first!,
+	"6".unicodeScalars.first!,
+	"7".unicodeScalars.first!,
+	"8".unicodeScalars.first!,
+	"9".unicodeScalars.first!,
+	"a".unicodeScalars.first!,
+	"b".unicodeScalars.first!,
+	"c".unicodeScalars.first!,
+	"d".unicodeScalars.first!,
+	"e".unicodeScalars.first!,
+	"f".unicodeScalars.first!
 ]
+


### PR DESCRIPTION
Serializing is now done by calling `try json.jsonString()` Cleaned up naming
- `JSONValue` -> `JSON`
- `JSON*` -> `*`
- Lowercase enum cases to avoid type name collisions and follow swift 3 guidelines
- Removed `JSONNumberType`. JSON now has two cases that cover it. `.integer` `.double`

Parser is unchanged save `JSONParser.parse[String|Data]` both are now just `JSONParser.parse`

Accessing JSON values now looks neater thanks to an extension on Optional. This extension allows a access style that is very similar to [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON)

Some things that are outstanding are updates to `README.md` and a new implementation of a pretty printer. The pretty printer must take a new approach now, I believe the only way for it to work now is to insert indentation into the string generated by `json.jsonString()`.

The performance comparison should also be done for parsing _and_ serialization.

Once you have reviewed the changes made I will update the `README` with new usage instructions.
