### PR TITLE
Improve literal type conversions

### DIFF
--- a/JSONCoreTests/JSONCoreTests.swift
+++ b/JSONCoreTests/JSONCoreTests.swift
@@ -76,7 +76,7 @@ class JSONCoreTests: XCTestCase {
     
     func expectString(string: String, json: JSON, file: String = __FILE__, line: UInt = __LINE__) {
         do {
-            let serialized = try json.jsonString()
+            let serialized = try json.serialized()
             XCTAssertEqual(string, serialized, file: file, line: line)
         } catch let err {
             if let printableError = err as? CustomStringConvertible {
@@ -184,7 +184,7 @@ class JSONCoreTests: XCTestCase {
             "str": "x",
             "null": nil
         ]
-        let str = try! obj.jsonString()
+        let str = try! obj.serialized()
         let returnedObj = try! JSONParser.parse(str.unicodeScalars)
         XCTAssertEqual(returnedObj, obj)
     }
@@ -195,7 +195,7 @@ class JSONCoreTests: XCTestCase {
             [4, 5, 6]
         ]
         let expected = "[\n  [\n    1,\n    2,\n    3\n  ],\n  [\n    4,\n    5,\n    6\n  ]\n]"
-        let str = try! arr.jsonString(prettyPrint: true)
+        let str = try! arr.serialized(prettyPrint: true)
         XCTAssertEqual(str, expected)
     }
     
@@ -206,7 +206,7 @@ class JSONCoreTests: XCTestCase {
             ]
         ]
         let expected = "{\n  \"test\": {\n    \"1\": 2\n  }\n}"
-        let str = try! obj.jsonString(prettyPrint: true)
+        let str = try! obj.serialized(prettyPrint: true)
         XCTAssertEqual(str, expected)
     }
     
@@ -230,7 +230,7 @@ class JSONCoreTests: XCTestCase {
             ]
         ]
         
-        let jsonString = try! json.jsonString()
+        let jsonString = try! json.serialized()
         
         let json2 = try! JSONParser.parse(jsonString)
         

--- a/JSONCoreTests/JSONCoreTests.swift
+++ b/JSONCoreTests/JSONCoreTests.swift
@@ -168,7 +168,7 @@ class JSONCoreTests: XCTestCase {
     
     func testSerializeArray() {
         let arr: JSON = [
-            1, 2.1, true, false, "x", nil
+            1, 2.1, true, false, "x", JSON.null
         ]
         let nestedArr: JSON = [arr]
         expectString("[1,2.1,true,false,\"x\",null]", json: arr)
@@ -182,7 +182,7 @@ class JSONCoreTests: XCTestCase {
             "true": true,
             "false": false,
             "str": "x",
-            "null": nil
+            "null": JSON.null
         ]
         let str = try! obj.serialized()
         let returnedObj = try! JSONParser.parse(str.unicodeScalars)
@@ -191,8 +191,8 @@ class JSONCoreTests: XCTestCase {
     
     func testPrettyPrintNestedArray() {
         let arr: JSON = [
-            [1, 2, 3],
-            [4, 5, 6]
+            [1, 2, 3] as JSON,
+            [4, 5, 6] as JSON
         ]
         let expected = "[\n  [\n    1,\n    2,\n    3\n  ],\n  [\n    4,\n    5,\n    6\n  ]\n]"
         let str = try! arr.serialized(prettyPrint: true)
@@ -203,7 +203,7 @@ class JSONCoreTests: XCTestCase {
         let obj: JSON = [
             "test": [
                 "1": 2
-            ]
+            ] as JSON
         ]
         let expected = "{\n  \"test\": {\n    \"1\": 2\n  }\n}"
         let str = try! obj.serialized(prettyPrint: true)
@@ -221,13 +221,13 @@ class JSONCoreTests: XCTestCase {
                     "usb2",
                     "thunderbolt1",
                     "thunderbolt2"
-                ],
+                ] as JSON,
                 "memory": [
                     "capacity": 8,
                     "clock": 1.6,
                     "type": "DDR3"
-                ]
-            ]
+                ] as JSON
+            ] as JSON
         ]
         
         let jsonString = try! json.serialized()
@@ -246,7 +246,7 @@ class JSONCoreTests: XCTestCase {
     }
     
     func testSubscriptSetter() {
-        var json: JSON = ["height": 1.90, "array": [1, 2, 3]]
+        var json: JSON = ["height": 1.90, "array": [1, 2, 3] as JSON]
         XCTAssertEqual(json["height"].double, 1.90)
         json["height"] = 1.91
         XCTAssertEqual(json["height"].double, 1.91)
@@ -254,5 +254,30 @@ class JSONCoreTests: XCTestCase {
         XCTAssertEqual(json["array"][0], 1)
         json["array"][0] = 4
         XCTAssertEqual(json["array"][0], 4)
+    }
+    
+    func testArrayLiteralConversion() {
+        enum Color: String, JSONEncodable {
+            case Red, Green, Blue
+            
+            func encodedToJSON() -> JSON {
+                return JSON.string(rawValue)
+            }
+        }
+        
+        struct Person: JSONEncodable {
+            var name: String
+            var favoriteColor: Color
+            
+            func encodedToJSON() -> JSON {
+                return ["name": name, "favoriteColor": favoriteColor]
+            }
+        }
+        
+        let bob = Person(name: "Bob Doe", favoriteColor: .Green)
+        
+        let json: JSON = ["name": bob.name, "favoriteColor": bob.favoriteColor]
+        
+        XCTAssertEqual(json, bob.encodedToJSON())
     }
 }

--- a/Source/JSONCore.swift
+++ b/Source/JSONCore.swift
@@ -36,7 +36,7 @@ public enum JSON {
     case string(String)
     case integer(JSONInteger)
     case double(Double)
-    
+
     /**
         Turns a nested graph of `JSON`s into a Swift `String`. This produces JSON data that
         strictly conforms to [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
@@ -45,7 +45,7 @@ public enum JSON {
     public func serialized(prettyPrint prettyPrint: Bool = false, lineEndings: JSONSerializer.LineEndings = .Unix) throws -> String {
         return try JSONSerializer(value: self, prettyPrint: prettyPrint, lineEndings: lineEndings).serialize()
     }
-    
+
     /// Returns this enum's associated Array value if it is one, `nil` otherwise.
     public var array: [JSON]? {
         guard case .array(let a) = self else { return nil }
@@ -173,7 +173,7 @@ extension JSON: StringLiteralConvertible {
 
 extension JSON: ArrayLiteralConvertible {
     public init(arrayLiteral elements: JSONEncodable...) {
-			self = .array(elements.map({ $0.encodedToJSON() }))
+            self = .array(elements.map({ $0.encodedToJSON() }))
     }
 }
 
@@ -270,7 +270,7 @@ extension Optional where Wrapped: _JSONType {
             guard let o = (self as? JSON)?.object else { return nil }
             return o[key]
         }
-        
+
         set {
             guard var o = (self as? JSON)?.object else { return }
             switch newValue {
@@ -288,7 +288,7 @@ extension Optional where Wrapped: _JSONType {
             guard let a = (self as? JSON)?.array where a.indices ~= index else { return nil }
             return a[index]
         }
-        
+
         set {
             guard var a = (self as? JSON)?.array else { return }
             switch newValue {
@@ -297,7 +297,7 @@ extension Optional where Wrapped: _JSONType {
                 a[index] = value
                 self = (JSON.array(a) as? Wrapped)
             }
-            
+
         }
     }
 
@@ -868,7 +868,7 @@ extension JSONParser {
     It can optionally pretty-print the output for debugging, but this comes with a non-negligible performance cost.
 */
 public class JSONSerializer {
-    
+
     /// What line endings should the pretty printer use
     public enum LineEndings: String {
         /// Unix (i.e Linux, Darwin) line endings: line feed
@@ -878,10 +878,10 @@ public class JSONSerializer {
     }
     /// Whether this serializer will pretty print output or not.
     public let prettyPrint: Bool
-    
+
     /// What line endings should the pretty printer use
     public let lineEndings: LineEndings
-    
+
     /**
      Designated initializer for `JSONSerializer`, which requires an input `JSONValue`.
      - Parameter value: The `JSONValue` to convert to a `String`.
@@ -894,7 +894,7 @@ public class JSONSerializer {
         self.rootValue = value
         self.lineEndings = lineEndings
     }
-    
+
     /**
      Shortcut for creating a `JSONSerializer` and having it serialize the given
      value.
@@ -909,7 +909,7 @@ public class JSONSerializer {
         let serializer = JSONSerializer(value: value, prettyPrint: prettyPrint)
         return try serializer.serialize()
     }
-    
+
     /**
      Serializes the value passed during initialization.
      - Returns: The serialized value as a `String`.
@@ -919,7 +919,7 @@ public class JSONSerializer {
         try serializeValue(rootValue)
         return output
     }
-    
+
     // MARK: Internals: Properties
     let rootValue: JSON
     var output: String = ""
@@ -927,13 +927,13 @@ public class JSONSerializer {
 
 // MARK: JSONSerializer Internals
 extension JSONSerializer {
-    
+
     func serializeValue(value: JSON, indentLevel: Int = 0) throws {
         switch value {
-		case .double(let d):
-			try serializeDouble(d)
-		case .integer(let i):
-			serializeInt(i)
+        case .double(let d):
+            try serializeDouble(d)
+        case .integer(let i):
+            serializeInt(i)
         case .null:
             serializeNull()
         case .string(let s):
@@ -946,7 +946,7 @@ extension JSONSerializer {
             try serializeArray(a, indentLevel: indentLevel)
         }
     }
-    
+
     func serializeObject(obj: [String : JSON], indentLevel: Int = 0) throws {
         output.append(leftCurlyBracket)
         serializeNewline()
@@ -962,14 +962,14 @@ extension JSONSerializer {
             i += 1
             if i != obj.count {
                 output.append(comma)
-                
+
             }
             serializeNewline()
         }
         serializeSpaces(indentLevel)
         output.append(rightCurlyBracket)
     }
-    
+
     func serializeArray(arr: [JSON], indentLevel: Int = 0) throws {
         output.append(leftSquareBracket)
         serializeNewline()
@@ -986,7 +986,7 @@ extension JSONSerializer {
         serializeSpaces(indentLevel)
         output.append(rightSquareBracket)
     }
-    
+
     func serializeString(str: String) {
         output.append(quotationMark)
         var generator = str.unicodeScalars.generate()
@@ -1022,19 +1022,19 @@ extension JSONSerializer {
         }
         output.append(quotationMark)
     }
-    
+
     func serializeDouble(f: Double) throws {
-			guard f.isFinite else { throw JSONSerializeError.InvalidNumber }
+            guard f.isFinite else { throw JSONSerializeError.InvalidNumber }
           // TODO: Is CustomStringConvertible for number types affected by locale?
           // TODO: Is CustomStringConvertible for Double fast?
           output.appendContentsOf(f.description)
     }
-	
+
     func serializeInt(i: JSONInteger) {
         // TODO: Is CustomStringConvertible for number types affected by locale?
         output.appendContentsOf(i.description)
     }
-	
+
     func serializeBool(bool: Bool) {
         switch bool {
         case true:
@@ -1043,18 +1043,18 @@ extension JSONSerializer {
             output.appendContentsOf("false")
         }
     }
-	
+
     func serializeNull() {
         output.appendContentsOf("null")
     }
-    
+
     @inline(__always)
     private final func serializeNewline() {
         if prettyPrint {
             output.appendContentsOf(lineEndings.rawValue)
         }
     }
-    
+
     @inline(__always)
     private final func serializeSpaces(indentLevel: Int = 0) {
         if prettyPrint {


### PR DESCRIPTION
Allow more meaningful initialization of JSON from literals

Allows `[object.key: object.value]` to initialize JSON. Due to Arrays and Dictionaries being unable to conform to protocols conditionally with Type Constraints they can no longer be used directly as literals and must first be converted to their JSON representation.

Arrays

``` swift
let json: JSON = ["key": [1, 2, 3]]
```

becomes

``` swift
let json: JSON = ["key": [1, 2, 3] as JSON]`
```

Dictionaries

``` swift
let json: JSON = ["key": ["key": "value"]]
```

becomes

``` swift
let json: JSON = ["key": ["key": "value"] as JSON]]
```

Nil

``` swift
let json: JSON = ["key": nil]
```

becomes

``` swift
let json: JSON = ["key": JSON.null]
```

The advantage being:

``` swift
func encodedAsJSON() -> JSON {
  var json: JSON = [:]
  json["username"] = name
  json["wins"] = wins
  json["loses"] = loses
  return json
}
```

becomes

``` swift
func encodedAsJSON() -> JSON {
  return ["username": name, "wins": wins, "loses": loses]
}
```

Since most people wouldn't be creating `JSON` with static literals I believe the tradeoffs of this change are worthwhile.
