### PR TITLE
Fixed parsing of empty JSON arrays

### DIFF
--- a/JSONCore.xcodeproj/project.pbxproj
+++ b/JSONCore.xcodeproj/project.pbxproj
@@ -117,7 +117,10 @@
 				8BAD3FC91C241E1200D362C5 /* JSONCore Performance Tests */,
 				8B4714B01BDA647800D29CDC /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		8B4714B01BDA647800D29CDC /* Products */ = {
 			isa = PBXGroup;
@@ -866,6 +869,7 @@
 				8BAD3FD21C241E1200D362C5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8BEEBF391BDB0FB400F702C8 /* Build configuration list for PBXNativeTarget "JSONCore watchOS" */ = {
 			isa = XCConfigurationList;

--- a/JSONCoreTests/JSONCoreTests.swift
+++ b/JSONCoreTests/JSONCoreTests.swift
@@ -48,7 +48,7 @@ class JSONCoreTests: XCTestCase {
         super.tearDown()
     }
     
-    func expectError(error: JSONParseError, json: String, file: String = __FILE__, line: UInt = __LINE__) {
+    func expectError(error: JSONParseError, json: String, file: StaticString = #file, line: UInt = #line) {
         do {
             try JSONParser.parse(json.unicodeScalars)
             XCTFail("Expected error, got success", file: file, line: line)
@@ -57,7 +57,7 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectErrorString(error: String, json: String, file: String = __FILE__, line: UInt = __LINE__) {
+    func expectErrorString(error: String, json: String, file: StaticString = #file, line: UInt = #line) {
         do {
             try JSONParser.parse(json.unicodeScalars)
             XCTFail("Expected error, got success", file: file, line: line)
@@ -69,7 +69,7 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectValue(value: JSON, json: String, file: String = __FILE__, line: UInt = __LINE__) {
+    func expectValue(value: JSON, json: String, file: StaticString = #file, line: UInt = #line) {
         do {
             let parsedValue = try JSONParser.parse(json.unicodeScalars)
             XCTAssertEqual(value, parsedValue, file: file, line: line)
@@ -80,7 +80,7 @@ class JSONCoreTests: XCTestCase {
         }
     }
     
-    func expectString(string: String, json: JSON, file: String = __FILE__, line: UInt = __LINE__) {
+    func expectString(string: String, json: JSON, file: StaticString = #file, line: UInt = #line) {
         do {
             let serialized = try json.serialized()
             XCTAssertEqual(string, serialized, file: file, line: line)
@@ -131,6 +131,10 @@ class JSONCoreTests: XCTestCase {
     func testParseUnicode() {
         expectValue(.string("и"), json: "\"\\u0438\"")
         expectValue(.string("𝄞"), json: "\"\\ud834\\udd1e\"")
+    }
+    
+    func testParseArray() {
+        expectValue(.array([]), json: "[\n ]")
     }
     
     func testSerializeBool() {

--- a/JSONCoreTests/JSONCoreTests.swift
+++ b/JSONCoreTests/JSONCoreTests.swift
@@ -134,7 +134,7 @@ class JSONCoreTests: XCTestCase {
     }
     
     func testParseArray() {
-        expectValue(.array([]), json: "[\n ]")
+        expectValue(.array([]), json: "[\n  \n]")
     }
     
     func testSerializeBool() {

--- a/Source/JSONCore.swift
+++ b/Source/JSONCore.swift
@@ -593,6 +593,15 @@ extension JSONParser {
             return JSON.array(arrBuilder)
         }
         outerLoop: repeat {
+            
+            switch scalar {
+            case rightSquareBracket: return JSON.array(arrBuilder)
+            case "\n", "\r", "\t", " ":
+                try nextScalar()
+                break
+            default: ()
+            }
+            
             let value = try nextValue()
             arrBuilder.append(value)
             switch value {

--- a/Source/JSONCore.swift
+++ b/Source/JSONCore.swift
@@ -588,17 +588,13 @@ extension JSONParser {
         }
         var arrBuilder = [JSON]()
         try nextScalar()
-        if scalar == rightSquareBracket {
-            // Empty array
-            return JSON.array(arrBuilder)
-        }
         outerLoop: repeat {
             
             switch scalar {
             case rightSquareBracket: return JSON.array(arrBuilder)
             case "\n", "\r", "\t", " ":
                 try nextScalar()
-                break
+                continue
             default: ()
             }
             


### PR DESCRIPTION
Parsing failed when they had whitespace characters in them.
Updated test targets to `swift 2.2`

Fixes #9 
